### PR TITLE
feat: Automatically inject type definitions

### DIFF
--- a/.changeset/eleven-jobs-drop.md
+++ b/.changeset/eleven-jobs-drop.md
@@ -1,0 +1,5 @@
+---
+"astro-lilypond": patch
+---
+
+Automatically inject type definitions to allow importing .ly, .ily, and .lilypond files with Vite/Astro

--- a/.changeset/eleven-jobs-drop.md
+++ b/.changeset/eleven-jobs-drop.md
@@ -2,4 +2,4 @@
 "astro-lilypond": patch
 ---
 
-Automatically inject type definitions to allow importing .ly, .ily, and .lilypond files with Vite/Astro
+Automatically inject type definitions to allow importing `.ly`, `.ily`, and `.lilypond` files without manually editing `env.d.ts`.

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -11,6 +11,8 @@ import type { LilypondPluginOptions, OutputFormat } from "./util.js";
 
 const execFileAsync = promisify(execFile);
 
+const LY_EXTENSIONS = [".ly", ".lilypond", ".ily"] as const;
+
 export type { OutputFormat };
 export type { LilypondPluginOptions };
 
@@ -41,7 +43,7 @@ function lyFilePlugin(options: LilypondOptions): Plugin {
 		name: "vite-plugin-astro-lilypond-ly",
 		enforce: "pre",
 		async transform(source, id) {
-			if (!id.endsWith(".ly") && !id.endsWith(".lilypond")) return;
+			if (!LY_EXTENSIONS.some(ext => id.endsWith(ext))) return;
 			const src = options.version ? prependVersion(source, options.version) : source;
 			const { format, resolution } = resolveFormat(options.format ?? "svg");
 				const buf = await render(src, { format, resolution, crop: options.crop ?? true });
@@ -135,6 +137,15 @@ export default function lilypond(options: LilypondOptions = {}): AstroIntegratio
 						"`unified(…)` from `@astrojs/markdown-remark`, then add this integration. " +
 						`Detected processor: ${existingProcessor?.name ?? "none"}.`,
 				);
+			},
+
+			"astro:config:done": ({ injectTypes }) => {
+				injectTypes({
+					filename: "ly-types.d.ts",
+					content: LY_EXTENSIONS
+						.map(ext => `declare module "*${ext}" {\n  const html: string;\n  export default html;\n}`)
+						.join("\n"),
+				});
 			},
 		},
 	};

--- a/package/tests/integration.test.ts
+++ b/package/tests/integration.test.ts
@@ -26,6 +26,39 @@ describe("lilypond integration", () => {
 		expect(typeof integration.hooks?.["astro:config:setup"]).toBe("function");
 	});
 
+	describe("vite plugin transform", () => {
+		async function getVitePlugin(opts = {}) {
+			const updateConfig = vi.fn();
+			vi.doMock("@astrojs/markdown-satteri", () => ({
+				satteri: vi.fn((o: unknown) => ({ name: "satteri", options: o })),
+				isSatteriProcessor: vi.fn(() => true),
+			}));
+			const integration = lilypond(opts);
+			await integration.hooks["astro:config:setup"]!({
+				config: { markdown: { processor: { name: "satteri", options: {} } } },
+				updateConfig,
+				logger: { info: vi.fn(), warn: vi.fn() },
+			} as never);
+			vi.doUnmock("@astrojs/markdown-satteri");
+			const { plugins } = (updateConfig.mock.calls[0][0] as { vite: { plugins: unknown[] } }).vite;
+			return plugins[0] as { transform: (src: string, id: string) => Promise<{ code: string } | undefined> };
+		}
+
+		it("transforms .ily files", async () => {
+			const plugin = await getVitePlugin();
+			// transform returns undefined for unrecognized extensions
+			const skipped = await plugin.transform("", "score.txt");
+			expect(skipped).toBeUndefined();
+		});
+
+		it.each([".ly", ".lilypond", ".ily"])("handles %s extension", async (ext) => {
+			const plugin = await getVitePlugin();
+			// render is the actual lilypond binary call — we only verify the plugin
+			// doesn't skip the file; a thrown error is fine here
+			await expect(plugin.transform("", `score${ext}`)).rejects.toThrow();
+		});
+	});
+
 	it("registers the Sätteri mdast plugin when processor is satteri", async () => {
 		const { updateConfig, logger }: SetupHookArgs = {
 			config: {},
@@ -104,6 +137,37 @@ describe("lilypond integration", () => {
 				logger,
 			} as never),
 		).rejects.toThrow("processor-based");
+	});
+
+	it("has an astro:config:done hook", () => {
+		const integration = lilypond();
+		expect(typeof integration.hooks?.["astro:config:done"]).toBe("function");
+	});
+
+	it("injects types with the correct filename", () => {
+		const injectTypes = vi.fn();
+		const integration = lilypond();
+		integration.hooks["astro:config:done"]!({ injectTypes } as never);
+		expect(injectTypes).toHaveBeenCalledOnce();
+		expect(injectTypes.mock.calls[0][0].filename).toBe("ly-types.d.ts");
+	});
+
+	it("injected types declare modules for .ly, .lilypond, and .ily", () => {
+		const injectTypes = vi.fn();
+		const integration = lilypond();
+		integration.hooks["astro:config:done"]!({ injectTypes } as never);
+		const { content } = injectTypes.mock.calls[0][0] as { content: string };
+		expect(content).toContain('declare module "*.ly"');
+		expect(content).toContain('declare module "*.lilypond"');
+		expect(content).toContain('declare module "*.ily"');
+	});
+
+	it("injected type declarations export a default html string", () => {
+		const injectTypes = vi.fn();
+		const integration = lilypond();
+		integration.hooks["astro:config:done"]!({ injectTypes } as never);
+		const { content } = injectTypes.mock.calls[0][0] as { content: string };
+		expect(content.match(/export default html/g)?.length).toBe(3);
 	});
 
 	it("includes the detected processor name in the error", async () => {


### PR DESCRIPTION
Automatically inject type definitions to allow importing `.ly`, `.ily`, and `.lilypond` files without manually editing `env.d.ts`.