### PR TITLE
Use Cairo backend, modify API for `resolution`, allow build process to emit logs from LilyPond

### DIFF
--- a/.changeset/cuddly-turkeys-heal.md
+++ b/.changeset/cuddly-turkeys-heal.md
@@ -1,0 +1,5 @@
+---
+"astro-lilypond": patch
+---
+
+Allow LilyPond to emit text during builds for better insight into warnings and errors from `.ly` compilation.

--- a/.changeset/eighty-beers-bet.md
+++ b/.changeset/eighty-beers-bet.md
@@ -1,0 +1,27 @@
+---
+"astro-lilypond": minor
+---
+
+BREAKING: The integration has changed how `resolution` is set in order to mirror the API shape of LilyPond's command line tools.
+
+Previously, resolution was set by passing an object with `type: "png"` to `format`:
+
+```js
+lilypond({
+  format: {
+    type: "png",
+    resolution: 300
+  }
+})
+```
+
+Now, resolution is its own config entry, separate from `format`:
+
+```js
+lilypond({
+  format: "png",
+  resolution: 300
+})
+```
+
+Note that `resolution` still only applies when format is set to `png`.

--- a/.changeset/open-eggs-call.md
+++ b/.changeset/open-eggs-call.md
@@ -1,0 +1,7 @@
+---
+"astro-lilypond": patch
+---
+
+Use LilyPond's `cairo` backend renderer instead of the default `ps` renderer. From LilyPond v2.26.0's [major changes](https://lilypond.org/doc/v2.26/Documentation/changes/major-changes-in-lilypond):
+
+> Instead of generating PostScript or SVG output by itself, LilyPond can now use the Cairo library to produce its output. This is referred to as the ‘Cairo backend’, and can be turned on using the -dbackend=cairo command-line option. This works for all output formats (PDF, SVG, PNG, PostScript), and brings speed and rendering fidelity improvements in SVG output in particular. However, keep in mind that this backend does not yet implement all features of the default backends. Among the features not currently supported are PDF outlines, the -dembed-source-code option for PDF, and the output-attributes property for SVG.

--- a/docs/src/components/LilyPondExample.astro
+++ b/docs/src/components/LilyPondExample.astro
@@ -7,30 +7,25 @@ interface Props {
   code: string;
   /** `<Code>` frame title, e.g. the source filename. */
   title: string;
-  class?: string | undefined;
-  style?: string | undefined;
   summary?: string;
 }
 
-const {
-  content,
-  code,
-  title,
-  class: className,
-  style,
-  summary = "View source",
-} = Astro.props;
+const { content, code, title, summary = "View source" } = Astro.props;
 ---
 
-<LilyPond content={content} class={className} style={style} />
+<LilyPond content={content} class="example" } />
 
 <details>
   <summary>{summary}</summary>
-  <Code code={code} lang="lilypondtext" title={title} class="example" />
+  <Code code={code} lang="lilypondtext" title={title} class="example-code" />
 </details>
 
 <style>
-  .example :global(.frame pre) {
+  .example {
+    width: 100%;
+  }
+
+  .example-code :global(.frame pre) {
     max-height: min(68vh, 600px);
     overflow: auto;
   }

--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -8,7 +8,7 @@ import versionExample from "../../examples/version-example.ly?raw";
 
 Pass options to the integration when registering it in `astro.config.mjs`:
 
-```js {7-9}
+```js
 // astro.config.mjs
 import { defineConfig } from 'astro/config';
 import lilypond from 'astro-lilypond';
@@ -52,7 +52,7 @@ Blocks with an explicit `\version` declaration will always use that version, reg
 
 ### `format`
 
-**Type:** `"svg" | "png" | { type: "png"; resolution: number }`  
+**Type:** `"svg" | "png"`  
 **Default:** `"svg"`
 
 The output format passed to the LilyPond binary. Controls how the rendered output is embedded in the page.
@@ -68,23 +68,20 @@ export default defineConfig({
 });
 ```
 
-| Value | Embedded as |
-|---|---|
-| `"svg"` | Inline `<svg>` element (default) |
-| `"png"` | `<img>` element with a base64 data URI, at the default resolution (144 DPI) |
-| `{ type: "png", resolution: number }` | `<img>` element with a base64 data URI, at the specified DPI |
+### `resolution`
 
-If you need higher quality PNGs, pass an object with `type: "png"` and `resolution`:
+**Type:** `number`  
+**Default:** `144`
 
-```js {5-8}
+Resolution to render `.png` files, in DPI. Only works when `format` is set to `png`.
+
+```js {4-7}
 // astro.config.mjs
 export default defineConfig({
    integrations: [
     lilypond({
-      format: {
-        type: "png",
-        resolution: 300
-      }
+      format: "png",
+      resolution: 300
     }),
   ],
 });

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -5,15 +5,14 @@ import type { Plugin } from "vite";
 import { remarkLilypondPlugin } from "./remark-plugin.js";
 import { rehypeLilypondPlugin } from "./rehype-plugin.js";
 import { satteriLilypondPlugin } from "./satteri-plugin.js";
-import { render } from "./render.js";
-import { includePathsFor, prependVersion, renderToHtml, resolveFormat } from "./util.js";
-import type { LilypondPluginOptions, OutputFormat } from "./util.js";
+import { defaultOptions, render } from "./render.js";
+import { includePathsFor, prependVersion, renderToHtml } from "./util.js";
+import type { LilypondPluginOptions } from "./util.js";
 
 const execFileAsync = promisify(execFile);
 
 const LY_EXTENSIONS = [".ly", ".lilypond", ".ily"] as const;
 
-export type { OutputFormat };
 export type { LilypondPluginOptions };
 
 export interface LilypondOptions extends LilypondPluginOptions {
@@ -28,10 +27,13 @@ export interface LilypondOptions extends LilypondPluginOptions {
 	 * Output format. Defaults to `"svg"`.
 	 *
 	 * - `"svg"` — inline SVG embedded directly in the HTML (default)
-	 * - `"png"` — `<img>` element with a base64 data URI, at the default resolution
-	 * - `{ type: "png", resolution: number }` — PNG at a specific DPI
+	 * - `"png"` — `<img>` element with a base64 data URI
 	 */
-	format?: OutputFormat;
+	format?: "svg" | "png";
+	/**
+	 * Resolution in DPI (only applies to PNG). Defaults to `144`.
+	 */
+	resolution?: number;
 	/**
 	 * Crop the output tightly to the content bounding box. Defaults to `true`.
 	 */
@@ -45,11 +47,11 @@ function lyFilePlugin(options: LilypondOptions): Plugin {
 		async transform(source, id) {
 			if (!LY_EXTENSIONS.some(ext => id.endsWith(ext))) return;
 			const src = options.version ? prependVersion(source, options.version) : source;
-			const { format, resolution } = resolveFormat(options.format ?? "svg");
+			const format = options.format ?? defaultOptions.format;
 			const buf = await render(src, {
 				format,
-				resolution,
-				crop: options.crop ?? true,
+				resolution: options.resolution,
+				crop: options.crop,
 				includePaths: includePathsFor(id),
 			});
 			return { code: `export default ${JSON.stringify(renderToHtml(buf, format))}` };
@@ -95,7 +97,7 @@ export default function lilypond(options: LilypondOptions = {}): AstroIntegratio
 								...existingOptions,
 								mdastPlugins: [
 									...(existingOptions.mdastPlugins ?? []),
-									satteriLilypondPlugin({ version: options.version, format: options.format, crop: options.crop }),
+									satteriLilypondPlugin(options),
 								],
 							}),
 						},
@@ -123,11 +125,11 @@ export default function lilypond(options: LilypondOptions = {}): AstroIntegratio
 								...existingOptions,
 								remarkPlugins: [
 									...(existingOptions.remarkPlugins ?? []),
-									[remarkLilypondPlugin, { version: options.version, format: options.format, crop: options.crop }],
+									[remarkLilypondPlugin, options],
 								],
 								rehypePlugins: [
 									...(existingOptions.rehypePlugins ?? []),
-									[rehypeLilypondPlugin, { version: options.version, format: options.format, crop: options.crop }],
+									[rehypeLilypondPlugin, options],
 								],
 							}),
 						},

--- a/package/src/rehype-plugin.ts
+++ b/package/src/rehype-plugin.ts
@@ -1,6 +1,6 @@
 import { visit } from "unist-util-visit";
-import { render } from "./render.js";
-import { includePathsFor, isLilypondLang, prependVersion, renderToHtml, resolveFormat } from "./util.js";
+import { defaultOptions, render } from "./render.js";
+import { includePathsFor, isLilypondLang, prependVersion, renderToHtml } from "./util.js";
 import type { LilypondPluginOptions } from "./util.js";
 
 // Raw node type — an Astro/rehype extension not in the standard @types/hast
@@ -48,9 +48,14 @@ export function rehypeLilypondPlugin(
 			const source = options.version
 				? prependVersion(raw, options.version)
 				: raw;
-			const { format, resolution } = resolveFormat(options.format ?? "svg");
+			const format = options.format ?? defaultOptions.format;
 
-			const promise = render(source, { format, resolution, crop: options.crop, includePaths })
+			const promise = render(source, {
+				format,
+				resolution: options.resolution,
+				crop: options.crop,
+				includePaths,
+			})
 				.then((buf): void => {
 					const rawNode: RawNode = {
 						type: "raw",

--- a/package/src/remark-plugin.ts
+++ b/package/src/remark-plugin.ts
@@ -1,8 +1,8 @@
 import type { Html, Root } from "mdast";
 import type { Plugin } from "unified";
 import { visit } from "unist-util-visit";
-import { render } from "./render.js";
-import { includePathsFor, isLilypondLang, prependVersion, renderToHtml, resolveFormat } from "./util.js";
+import { defaultOptions, render } from "./render.js";
+import { includePathsFor, isLilypondLang, prependVersion, renderToHtml } from "./util.js";
 import type { LilypondPluginOptions } from "./util.js";
 
 export type RemarkPluginOptions = LilypondPluginOptions;
@@ -20,9 +20,14 @@ export const remarkLilypondPlugin: Plugin<[RemarkPluginOptions?], Root> = (
 			const source = options.version
 				? prependVersion(node.value, options.version)
 				: node.value;
-			const { format, resolution } = resolveFormat(options.format ?? "svg");
+			const format = options.format ?? defaultOptions.format;
 
-			const promise = render(source, { format, resolution, crop: options.crop, includePaths })
+			const promise = render(source, {
+				format,
+				resolution: options.resolution,
+				crop: options.crop,
+				includePaths,
+			})
 				.then((buf): void => {
 					const htmlNode: Html = {
 						type: "html",

--- a/package/src/render.ts
+++ b/package/src/render.ts
@@ -6,45 +6,30 @@ import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
 
-// LilyPond sometimes hits an internal programming error but recovers and
-// still produces valid output (it logs "continuing, cross fingers" and exits
-// zero). Complex real-world scores with cross-staff spacing can legitimately
-// trigger this, so it shouldn't fail the build on its own.
-const BENIGN_STDERR_RE = /^programming error:.*\n^continuing, cross fingers$/gm;
+const FORMATS = ["png", "svg"] as const;
 
-function isBenignStderr(stderr: string): boolean {
-	return stderr.replace(BENIGN_STDERR_RE, "").trim() === "";
-}
-
-export type Format = "midi" | "pdf" | "ps" | "png" | "svg" | "eps";
-
-const FORMAT_FLAGS: Record<Format, string | null> = {
-	midi: null,
-	pdf: "--pdf",
-	png: "--png",
-	ps: "--ps",
-	svg: "--svg",
-	eps: "--eps",
-};
+export type Format = (typeof FORMATS)[number];
 
 export interface RenderOptions {
 	/** Output format. Defaults to `"svg"`. */
 	format?: Format;
+
 	/** Resolution in DPI (only applies to PNG). Defaults to `144`. */
 	resolution?: number;
+
 	/** Path to the `lilypond` binary. Defaults to `"lilypond"`. */
 	binaryPath?: string;
+
 	/**
-	 * Crop the output SVG tightly to the content bounding box using
-	 * `--define-default crop`. Defaults to `true`.
+	 * Crop the output tightly to the content bounding box.
+	 * Disable if full-page renders are preferred.
+	 * Defaults to `true`.
 	 */
 	crop?: boolean;
+
 	/**
-	 * Extra directories LilyPond should search for `\include`d files, in
-	 * addition to its own library (via `-I`). Typically the directory
-	 * containing the source `.ly`/Markdown file, so sibling
-	 * `\include "foo.ily"` files resolve even though rendering happens in a
-	 * temp directory.
+	 * Extra directories LilyPond should search for `\include`d files.
+	 * Typically the directory containing the source `.ly`/Markdown file.
 	 */
 	includePaths?: string[];
 }
@@ -67,10 +52,9 @@ export async function render(
 		crop = defaultOptions.crop,
 		includePaths = [],
 	} = options;
-	const opts = { format, resolution, binaryPath, crop, includePaths };
 
-	if (!(opts.format in FORMAT_FLAGS)) {
-		throw new Error(`${opts.format} is not a supported format`);
+	if (!FORMATS.includes(format)) {
+		throw new Error(`${format} is not a supported format`);
 	}
 
 	const dir = await mkdtemp(join(tmpdir(), "astro-lilypond-"));
@@ -80,31 +64,48 @@ export async function render(
 	try {
 		await writeFile(inputPath, source, "utf8");
 
-		const args: string[] = [
-			FORMAT_FLAGS[opts.format],
-			`--define-default=resolution=${opts.resolution ?? 144}`,
+		const args = [
+			// Render the correct format
+			`--format=${format}`,
+
+			// Define defaults — these can be overridden with the appropriate flags
+			// inside of individual .ly files
+
+			// Disable point-and-click behavior on SVGs when clicking noteheads
 			"--define-default=no-point-and-click",
-			...(opts.crop ? ["--define-default=crop"] : []),
-			...opts.includePaths.map((p) => `--include=${p}`),
-			"--silent",
+			// Use the `cairo` backend for graphics rendering; faster than the default `ps` backend
+			// https://lilypond.org/doc/v2.26/Documentation/usage/advanced-command_002dline-options-for-lilypond
+			"--define-default=backend=cairo",
+			// Resolution for generating PNGs (set in DPI)
+			`--define-default=resolution=${resolution}`,
+			// Set cropping
+			`--define-default=crop=${crop ? "#t" : "#f"}`,
+
+			// If the LilyPond file imports from others via \include, make sure those files are included
+			...includePaths.map((p) => `--include=${p}`),
+
 			"--output",
 			outputBase,
 			inputPath,
-		].filter((a): a is string => a !== null);
+		];
 
+		// LilyPond writes its progress log, and any warnings/errors, to stderr
+		// even on success — surface it in the build output so it's visible,
+		// but let the exit code (not stderr content) decide pass/fail.
 		let stderr: string;
 		try {
-			({ stderr } = await execFileAsync(opts.binaryPath ?? "lilypond", args));
+			({ stderr } = await execFileAsync(binaryPath, args));
 		} catch (err) {
 			const errStderr =
 				err && typeof err === "object" && "stderr" in err
 					? String((err as { stderr: unknown }).stderr)
 					: undefined;
+			if (errStderr) process.stderr.write(errStderr);
 			throw new Error(errStderr || (err instanceof Error ? err.message : String(err)));
 		}
-		if (stderr && !isBenignStderr(stderr)) throw new Error(stderr);
+		if (stderr) process.stderr.write(stderr);
 
-		return await readOutputFile(outputBase, opts.format, opts.crop);
+		return await readOutputFile(outputBase, format, crop);
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}
@@ -129,7 +130,7 @@ async function readOutputFile(
 	}
 
 	// Regular output: single page → <base>.<format>, multi-page →
-	// <base>-1.<format> (svg/pdf/ps/eps) or <base>-page1.<format> (png).
+	// <base>-1.<format> (svg) or <base>-page1.<format> (png).
 	try {
 		return await readFile(`${base}.${format}`);
 	} catch {

--- a/package/src/satteri-plugin.ts
+++ b/package/src/satteri-plugin.ts
@@ -3,8 +3,8 @@ import type {
 	MdastPluginDefinition,
 	MdastVisitorContext,
 } from "satteri";
-import { render } from "./render.js";
-import { includePathsFor, isLilypondLang, prependVersion, renderToHtml, resolveFormat } from "./util.js";
+import { defaultOptions, render } from "./render.js";
+import { includePathsFor, isLilypondLang, prependVersion, renderToHtml } from "./util.js";
 import type { LilypondPluginOptions } from "./util.js";
 
 export type SatteriPluginOptions = LilypondPluginOptions;
@@ -25,9 +25,14 @@ export function satteriLilypondPlugin(
 			const source = options.version
 				? prependVersion(node.value, options.version)
 				: node.value;
-			const { format, resolution } = resolveFormat(options.format ?? "svg");
+			const format = options.format ?? defaultOptions.format;
 			const includePaths = includePathsFor(ctx.fileURL);
-			const buf = await render(source, { format, resolution, crop: options.crop, includePaths });
+			const buf = await render(source, {
+				format,
+				resolution: options.resolution,
+				crop: options.crop,
+				includePaths,
+			});
 			return { type: "html", value: renderToHtml(buf, format) };
 		},
 	};

--- a/package/src/util.ts
+++ b/package/src/util.ts
@@ -1,26 +1,16 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 
-export type OutputFormat = "svg" | "png" | { type: "png"; resolution: number };
-
 export interface LilypondPluginOptions {
 	version?: string;
-	format?: OutputFormat;
+	format?: "svg" | "png";
+	resolution?: number;
 	crop?: boolean;
 }
 
 /** Returns true for the fenced-block language identifiers that trigger SVG rendering. */
 export function isLilypondLang(lang: string | null | undefined): boolean {
 	return lang === "lilypond" || lang === "ly" || lang === "ily";
-}
-
-/** Normalises an OutputFormat value into a plain format string and optional resolution (DPI). */
-export function resolveFormat(format: OutputFormat): {
-	format: "svg" | "png";
-	resolution?: number;
-} {
-	if (typeof format === "string") return { format };
-	return { format: format.type, resolution: format.resolution };
 }
 
 /**

--- a/package/tests/unit/rehype-plugin.test.ts
+++ b/package/tests/unit/rehype-plugin.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("../../src/render", () => ({
 	render: vi.fn(),
+	defaultOptions: { format: "svg", resolution: 144, binaryPath: "lilypond", crop: true },
 }));
 
 import { render } from "../../src/render";
@@ -210,11 +211,12 @@ describe("rehypeLilypondPlugin", () => {
 		);
 	});
 
-	it("passes resolution DPI when format is an object", async () => {
+	it("passes resolution DPI when resolution is set", async () => {
 		const fakePng = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
 		mockRender.mockResolvedValue(fakePng);
 		const transformer = rehypeLilypondPlugin({
-			format: { type: "png", resolution: 300 },
+			format: "png",
+			resolution: 300,
 		});
 		const tree = makeTree([makeLilypondPre("\\score { }")]);
 

--- a/package/tests/unit/remark-plugin.test.ts
+++ b/package/tests/unit/remark-plugin.test.ts
@@ -3,6 +3,7 @@ import type { Code, Html, Paragraph, Root, Text } from "mdast";
 
 vi.mock("../../src/render", () => ({
 	render: vi.fn(),
+	defaultOptions: { format: "svg", resolution: 144, binaryPath: "lilypond", crop: true },
 }));
 
 import { render } from "../../src/render";
@@ -195,11 +196,12 @@ describe("remarkLilypondPlugin", () => {
 		);
 	});
 
-	it("passes resolution DPI when format is an object", async () => {
+	it("passes resolution DPI when resolution is set", async () => {
 		const fakePng = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
 		mockRender.mockResolvedValue(fakePng);
 		const plugin = remarkLilypondPlugin({
-			format: { type: "png", resolution: 300 },
+			format: "png",
+			resolution: 300,
 		}) as unknown as SimpleTransformer;
 		const tree = makeTree([
 			{ type: "code", lang: "lilypond", value: "\\score { }" } as Code,

--- a/package/tests/unit/render.test.ts
+++ b/package/tests/unit/render.test.ts
@@ -45,22 +45,28 @@ describe("render", () => {
 		expect(Buffer.isBuffer(result)).toBe(true);
 	});
 
-	it("passes --svg flag for svg format", async () => {
+	it("passes --format=svg flag for svg format", async () => {
 		await render("\\score { }", { format: "svg" });
 		const [, args] = mockExecFile.mock.calls[0] as unknown as [string, string[]];
-		expect(args).toContain("--svg");
+		expect(args).toContain("--format=svg");
 	});
 
-	it("passes --define-default=crop when crop is true", async () => {
+	it("passes the cairo backend", async () => {
+		await render("\\score { }");
+		const [, args] = mockExecFile.mock.calls[0] as unknown as [string, string[]];
+		expect(args).toContain("--define-default=backend=cairo");
+	});
+
+	it("passes --define-default=crop=#t when crop is true", async () => {
 		await render("\\score { }", { crop: true });
 		const [, args] = mockExecFile.mock.calls[0] as unknown as [string, string[]];
-		expect(args).toContain("--define-default=crop");
+		expect(args).toContain("--define-default=crop=#t");
 	});
 
-	it("omits --define-default=crop when crop is false", async () => {
+	it("passes --define-default=crop=#f when crop is false", async () => {
 		await render("\\score { }", { crop: false });
 		const [, args] = mockExecFile.mock.calls[0] as unknown as [string, string[]];
-		expect(args).not.toContain("--define-default=crop");
+		expect(args).toContain("--define-default=crop=#f");
 	});
 
 	it("crop is true by default", () => {
@@ -82,7 +88,7 @@ describe("render", () => {
 		await expect(render("bad")).rejects.toThrow("fatal error: bad input");
 	});
 
-	it("throws when lilypond writes an unrecognized warning to stderr even though it exits zero", async () => {
+	it("does not throw when lilypond writes warnings to stderr but exits zero", async () => {
 		mockExecFile.mockImplementation(
 			((_bin: string, _args: string[], cb: (err: null, res: { stdout: string; stderr: string }) => void) =>
 				cb(null, {
@@ -90,33 +96,23 @@ describe("render", () => {
 					stderr: "warning: some other unexpected warning",
 				})) as typeof execFile,
 		);
-		await expect(render("\\score { }")).rejects.toThrow(
-			"warning: some other unexpected warning",
-		);
-	});
-
-	it("does not throw for the known-benign 'programming error ... continuing, cross fingers' recovery warning", async () => {
-		mockExecFile.mockImplementation(
-			((_bin: string, _args: string[], cb: (err: null, res: { stdout: string; stderr: string }) => void) =>
-				cb(null, {
-					stdout: "",
-					stderr:
-						"programming error: cyclic dependency: calculation-in-progress encountered for VerticalAxisGroup.adjacent-pure-heights\ncontinuing, cross fingers\nprogramming error: cyclic dependency: calculation-in-progress encountered for VerticalAxisGroup.adjacent-pure-heights\ncontinuing, cross fingers",
-				})) as typeof execFile,
-		);
 		await expect(render("\\score { }")).resolves.toBeInstanceOf(Buffer);
 	});
 
-	it("still throws if real stderr content is mixed in with the benign recovery warning", async () => {
+	it("writes stderr to process.stderr for visibility even on success", async () => {
+		const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 		mockExecFile.mockImplementation(
 			((_bin: string, _args: string[], cb: (err: null, res: { stdout: string; stderr: string }) => void) =>
 				cb(null, {
 					stdout: "",
-					stderr:
-						"programming error: cyclic dependency: calculation-in-progress encountered for VerticalAxisGroup.adjacent-pure-heights\ncontinuing, cross fingers\nwarning: something actually wrong",
+					stderr: "Processing `input.ly'\nSuccess: compilation successfully completed",
 				})) as typeof execFile,
 		);
-		await expect(render("\\score { }")).rejects.toThrow("something actually wrong");
+		await render("\\score { }");
+		expect(writeSpy).toHaveBeenCalledWith(
+			"Processing `input.ly'\nSuccess: compilation successfully completed",
+		);
+		writeSpy.mockRestore();
 	});
 
 	it("passes --include for each includePaths entry so \\include can find sibling files", async () => {

--- a/package/tests/unit/satteri-plugin.test.ts
+++ b/package/tests/unit/satteri-plugin.test.ts
@@ -3,6 +3,7 @@ import type { Code, Html } from "mdast";
 
 vi.mock("../../src/render.js", () => ({
 	render: vi.fn(),
+	defaultOptions: { format: "svg", resolution: 144, binaryPath: "lilypond", crop: true },
 }));
 
 import { render } from "../../src/render.js";
@@ -153,10 +154,10 @@ describe("satteriLilypondPlugin", () => {
 		expect((result as Html).value).toContain(fakePng.toString("base64"));
 	});
 
-	it("passes resolution DPI when format is an object", async () => {
+	it("passes resolution DPI when resolution is set", async () => {
 		const fakePng = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
 		mockRender.mockResolvedValue(fakePng);
-		const plugin = satteriLilypondPlugin({ format: { type: "png", resolution: 300 } });
+		const plugin = satteriLilypondPlugin({ format: "png", resolution: 300 });
 		const node: Code = { type: "code", lang: "lilypond", value: "\\score { }" };
 
 		const result = await plugin.code!(node, {} as never);


### PR DESCRIPTION
- Allow LilyPond to emit text during builds for better insight into warnings and errors from `.ly` compilation.
- Update how `resolution` is set in order to mirror the API shape of LilyPond's command line tools.
- Use LilyPond's `cairo` backend renderer instead of the default `ps` renderer.