### PR TITLE
Emit source names when compiling scores for easier debugging

### DIFF
--- a/.changeset/sour-pants-guess.md
+++ b/.changeset/sour-pants-guess.md
@@ -1,0 +1,5 @@
+---
+"astro-lilypond": patch
+---
+
+Emit source names to build log when available for easier debugging

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -5,9 +5,10 @@ import starlightThemeFlexoki from 'starlight-theme-flexoki'
 import lilypondGrammar from "./src/lilypond.tmLanguage.mjs"
 
 export default defineConfig({
+  site: "https://lilypond.ky.fyi",
   integrations: [
     lilypond({
-      version: "2.24.0",
+      version: "2.26.0",
     }),
 		starlight({
 			title: "Astro LilyPond",

--- a/docs/src/components/examples/scores/ancient-headword.ly
+++ b/docs/src/components/examples/scores/ancient-headword.ly
@@ -1,9 +1,8 @@
 \version "2.25.5"
-\include "gregorian.ly"
 
 #(set-global-staff-size 23)
 
-\new VaticanaStaff {
+\new VaticanaScore {
   <<
     \new VaticanaVoice = "cantus" {
       \clef "vaticana-do3"

--- a/docs/src/components/examples/scores/example.ly
+++ b/docs/src/components/examples/scores/example.ly
@@ -1,5 +1,5 @@
 \relative c' {
   c4 d e f |
   g a b c~ |
-  \fermata c1 \bar "|."
+  c1\fermata \bar "|."
 }

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -6,7 +6,7 @@ import { remarkLilypondPlugin } from "./remark-plugin.js";
 import { rehypeLilypondPlugin } from "./rehype-plugin.js";
 import { satteriLilypondPlugin } from "./satteri-plugin.js";
 import { defaultOptions, render } from "./render.js";
-import { includePathsFor, prependVersion, renderToHtml } from "./util.js";
+import { includePathsFor, prependVersion, renderToHtml, sourceNameFor } from "./util.js";
 import type { LilypondPluginOptions } from "./util.js";
 
 const execFileAsync = promisify(execFile);
@@ -53,6 +53,7 @@ function lyFilePlugin(options: LilypondOptions): Plugin {
 				resolution: options.resolution,
 				crop: options.crop,
 				includePaths: includePathsFor(id),
+				sourceName: sourceNameFor(id),
 			});
 			return { code: `export default ${JSON.stringify(renderToHtml(buf, format))}` };
 		},

--- a/package/src/rehype-plugin.ts
+++ b/package/src/rehype-plugin.ts
@@ -1,6 +1,12 @@
 import { visit } from "unist-util-visit";
 import { defaultOptions, render } from "./render.js";
-import { includePathsFor, isLilypondLang, prependVersion, renderToHtml } from "./util.js";
+import {
+	includePathsFor,
+	isLilypondLang,
+	prependVersion,
+	renderToHtml,
+	sourceNameFor,
+} from "./util.js";
 import type { LilypondPluginOptions } from "./util.js";
 
 // Raw node type — an Astro/rehype extension not in the standard @types/hast
@@ -20,6 +26,7 @@ export function rehypeLilypondPlugin(
 	return async (tree, file) => {
 		const promises: Promise<void>[] = [];
 		const includePaths = includePathsFor(file?.path);
+		const sourceName = sourceNameFor(file?.path);
 
 		visit(tree, "element", (node, index, parent) => {
 			if (
@@ -55,6 +62,7 @@ export function rehypeLilypondPlugin(
 				resolution: options.resolution,
 				crop: options.crop,
 				includePaths,
+				sourceName,
 			})
 				.then((buf): void => {
 					const rawNode: RawNode = {

--- a/package/src/remark-plugin.ts
+++ b/package/src/remark-plugin.ts
@@ -2,7 +2,13 @@ import type { Html, Root } from "mdast";
 import type { Plugin } from "unified";
 import { visit } from "unist-util-visit";
 import { defaultOptions, render } from "./render.js";
-import { includePathsFor, isLilypondLang, prependVersion, renderToHtml } from "./util.js";
+import {
+	includePathsFor,
+	isLilypondLang,
+	prependVersion,
+	renderToHtml,
+	sourceNameFor,
+} from "./util.js";
 import type { LilypondPluginOptions } from "./util.js";
 
 export type RemarkPluginOptions = LilypondPluginOptions;
@@ -13,6 +19,7 @@ export const remarkLilypondPlugin: Plugin<[RemarkPluginOptions?], Root> = (
 	return async (tree, file) => {
 		const promises: Promise<void>[] = [];
 		const includePaths = includePathsFor(file?.path);
+		const sourceName = sourceNameFor(file?.path);
 
 		visit(tree, "code", (node, index, parent) => {
 			if (!isLilypondLang(node.lang) || index === undefined || !parent) return;
@@ -27,6 +34,7 @@ export const remarkLilypondPlugin: Plugin<[RemarkPluginOptions?], Root> = (
 				resolution: options.resolution,
 				crop: options.crop,
 				includePaths,
+				sourceName,
 			})
 				.then((buf): void => {
 					const htmlNode: Html = {

--- a/package/src/render.ts
+++ b/package/src/render.ts
@@ -1,6 +1,6 @@
 import { execFile } from "child_process";
 import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
-import { join } from "path";
+import { basename, join } from "path";
 import { tmpdir } from "os";
 import { promisify } from "util";
 
@@ -32,9 +32,17 @@ export interface RenderOptions {
 	 * Typically the directory containing the source `.ly`/Markdown file.
 	 */
 	includePaths?: string[];
+
+	/**
+	 * Base name to give the temp input file passed to LilyPond, so build
+	 * output (e.g. `Processing "bach-schenker.ly"`) identifies the source
+	 * instead of a generic `input.ly`. Falls back to `"input.ly"` when
+	 * omitted or unsafe to use as a filename.
+	 */
+	sourceName?: string;
 }
 
-export const defaultOptions: Required<Omit<RenderOptions, "includePaths">> = {
+export const defaultOptions: Required<Omit<RenderOptions, "includePaths" | "sourceName">> = {
 	format: "svg",
 	resolution: 144,
 	binaryPath: "lilypond",
@@ -51,6 +59,7 @@ export async function render(
 		binaryPath = defaultOptions.binaryPath,
 		crop = defaultOptions.crop,
 		includePaths = [],
+		sourceName,
 	} = options;
 
 	if (!FORMATS.includes(format)) {
@@ -58,7 +67,7 @@ export async function render(
 	}
 
 	const dir = await mkdtemp(join(tmpdir(), "astro-lilypond-"));
-	const inputPath = join(dir, "input.ly");
+	const inputPath = join(dir, safeInputFileName(sourceName));
 	const outputBase = join(dir, "output");
 
 	try {
@@ -109,6 +118,21 @@ export async function render(
 	} finally {
 		await rm(dir, { recursive: true, force: true });
 	}
+}
+
+/**
+ * Resolves the base name to use for the temp input file. Strips any
+ * directory components from `sourceName` (it may be a full path) and
+ * rejects anything that isn't a plain, safe file name, falling back to
+ * the generic `"input.ly"`.
+ */
+function safeInputFileName(sourceName: string | undefined): string {
+	if (!sourceName) return "input.ly";
+	const base = basename(sourceName);
+	if (!base || base === "." || base === ".." || !/^[\w.-]+$/.test(base)) {
+		return "input.ly";
+	}
+	return base;
 }
 
 async function readOutputFile(

--- a/package/src/satteri-plugin.ts
+++ b/package/src/satteri-plugin.ts
@@ -4,7 +4,13 @@ import type {
 	MdastVisitorContext,
 } from "satteri";
 import { defaultOptions, render } from "./render.js";
-import { includePathsFor, isLilypondLang, prependVersion, renderToHtml } from "./util.js";
+import {
+	includePathsFor,
+	isLilypondLang,
+	prependVersion,
+	renderToHtml,
+	sourceNameFor,
+} from "./util.js";
 import type { LilypondPluginOptions } from "./util.js";
 
 export type SatteriPluginOptions = LilypondPluginOptions;
@@ -27,11 +33,13 @@ export function satteriLilypondPlugin(
 				: node.value;
 			const format = options.format ?? defaultOptions.format;
 			const includePaths = includePathsFor(ctx.fileURL);
+			const sourceName = sourceNameFor(ctx.fileURL);
 			const buf = await render(source, {
 				format,
 				resolution: options.resolution,
 				crop: options.crop,
 				includePaths,
+				sourceName,
 			});
 			return { type: "html", value: renderToHtml(buf, format) };
 		},

--- a/package/src/util.ts
+++ b/package/src/util.ts
@@ -1,4 +1,4 @@
-import { dirname } from "path";
+import { basename, dirname } from "path";
 import { fileURLToPath } from "url";
 
 export interface LilypondPluginOptions {
@@ -31,6 +31,17 @@ export function includePathsFor(source: string | URL | null | undefined): string
 	if (!source) return [];
 	const path = typeof source === "string" ? source : fileURLToPath(source);
 	return [dirname(path)];
+}
+
+/**
+ * Derives `render()`'s `sourceName` from the source file's path or URL, so
+ * build output identifies the originating file instead of a generic
+ * `input.ly`. Returns `undefined` when the source location is unknown.
+ */
+export function sourceNameFor(source: string | URL | null | undefined): string | undefined {
+	if (!source) return undefined;
+	const path = typeof source === "string" ? source : fileURLToPath(source);
+	return basename(path);
 }
 
 /** Converts a rendered LilyPond buffer to an HTML string suitable for inline embedding. */

--- a/package/tests/unit/remark-plugin.test.ts
+++ b/package/tests/unit/remark-plugin.test.ts
@@ -55,6 +55,7 @@ describe("remarkLilypondPlugin", () => {
 			resolution: undefined,
 			crop: undefined,
 			includePaths: ["."],
+			sourceName: "test.md",
 		});
 		expect(tree.children[0]).toEqual({ type: "html", value: RENDERED_SVG });
 	});
@@ -81,6 +82,7 @@ describe("remarkLilypondPlugin", () => {
 			resolution: undefined,
 			crop: undefined,
 			includePaths: ["."],
+			sourceName: "test.md",
 		});
 		expect(tree.children[0]).toEqual({ type: "html", value: RENDERED_SVG });
 	});
@@ -97,6 +99,7 @@ describe("remarkLilypondPlugin", () => {
 			resolution: undefined,
 			crop: undefined,
 			includePaths: ["."],
+			sourceName: "test.md",
 		});
 		expect(tree.children[0]).toEqual({ type: "html", value: RENDERED_SVG });
 	});
@@ -141,6 +144,7 @@ describe("remarkLilypondPlugin", () => {
 			resolution: undefined,
 			crop: undefined,
 			includePaths: ["."],
+			sourceName: "test.md",
 		});
 	});
 
@@ -156,6 +160,7 @@ describe("remarkLilypondPlugin", () => {
 			resolution: undefined,
 			crop: undefined,
 			includePaths: ["."],
+			sourceName: "test.md",
 		});
 	});
 
@@ -171,6 +176,7 @@ describe("remarkLilypondPlugin", () => {
 			resolution: undefined,
 			crop: undefined,
 			includePaths: ["."],
+			sourceName: "test.md",
 		});
 		expect((tree.children[0] as Html).value).toBe(RENDERED_SVG);
 	});
@@ -190,6 +196,7 @@ describe("remarkLilypondPlugin", () => {
 			resolution: undefined,
 			crop: undefined,
 			includePaths: ["."],
+			sourceName: "test.md",
 		});
 		expect((tree.children[0] as Html).value).toContain(
 			'<img class="lilypond" src="data:image/png;base64,',
@@ -214,6 +221,7 @@ describe("remarkLilypondPlugin", () => {
 			resolution: 300,
 			crop: undefined,
 			includePaths: ["."],
+			sourceName: "test.md",
 		});
 		expect((tree.children[0] as Html).value).toContain(
 			'<img class="lilypond" src="data:image/png;base64,',
@@ -233,6 +241,7 @@ describe("remarkLilypondPlugin", () => {
 			resolution: undefined,
 			crop: false,
 			includePaths: ["."],
+			sourceName: "test.md",
 		});
 	});
 });


### PR DESCRIPTION
- All scores were emitting as `input.ly` to logs during build. Pass source names to the console to help when debugging issues that are raised by LilyPond during compilation.
- Fix a few score errors.
- Add `site` to config so that the Astro sitemap can be generated.