### PR TITLE
Serialize processing

### DIFF
--- a/.changeset/dry-snakes-greet.md
+++ b/.changeset/dry-snakes-greet.md
@@ -2,4 +2,4 @@
 "astro-lilypond": patch
 ---
 
-Serialize rendering to prevent race conditions when multiple lilypond processes run at once"
+Serialize rendering to prevent race conditions when multiple lilypond processes run at once.

--- a/.changeset/dry-snakes-greet.md
+++ b/.changeset/dry-snakes-greet.md
@@ -1,0 +1,5 @@
+---
+"astro-lilypond": patch
+---
+
+Serialize rendering to prevent race conditions when multiple lilypond processes run at once"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,13 +41,6 @@ jobs:
       - name: Add LilyPond to PATH
         run: echo "$HOME/lilypond-2.26.0/bin" >> "$GITHUB_PATH"
 
-      - name: Warm LilyPond font cache
-        # Force fontconfig to build its cache before attempting to render examples
-        # to prevent malformatted glyphs/fonts from displaying on the scores
-        run: |
-          echo '\version "2.26.0" { c4 }' > /tmp/warmup.ly
-          lilypond --define-default=backend=cairo --output=/tmp/warmup /tmp/warmup.ly
-
       - name: Build library
         run: pnpm --filter astro-lilypond build
 

--- a/package/src/render.ts
+++ b/package/src/render.ts
@@ -6,6 +6,20 @@ import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
 
+// Concurrent `lilypond` processes can race over shared, lazily-populated
+// caches, corrupting the output. Serialize invocations of the binary so
+// no two processes build at once.
+let invocationQueue: Promise<void> = Promise.resolve();
+
+function runExclusive<T>(task: () => Promise<T>): Promise<T> {
+	const result = invocationQueue.then(task, task);
+	invocationQueue = result.then(
+		() => undefined,
+		() => undefined,
+	);
+	return result;
+}
+
 const FORMATS = ["png", "svg"] as const;
 
 export type Format = (typeof FORMATS)[number];
@@ -102,7 +116,7 @@ export async function render(
 		// but let the exit code (not stderr content) decide pass/fail.
 		let stderr: string;
 		try {
-			({ stderr } = await execFileAsync(binaryPath, args));
+			({ stderr } = await runExclusive(() => execFileAsync(binaryPath, args)));
 		} catch (err) {
 			const errStderr =
 				err && typeof err === "object" && "stderr" in err

--- a/package/src/render.ts
+++ b/package/src/render.ts
@@ -6,8 +6,8 @@ import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
 
-// Concurrent `lilypond` processes can race over shared, lazily-populated
-// caches, corrupting the output. Serialize invocations of the binary so
+// Concurrent `lilypond` processes can encounter race conditions
+// and corrupt the output. Serialize invocations of the binary so
 // no two processes build at once.
 let invocationQueue: Promise<void> = Promise.resolve();
 


### PR DESCRIPTION
Serialize rendering to prevent race conditions when multiple lilypond processes run at once.