### PR TITLE
fix: Prevent rendered SVG elements from corrupting display via conflicts in `<use>` elements

### DIFF
--- a/.changeset/dry-snakes-greet.md
+++ b/.changeset/dry-snakes-greet.md
@@ -2,4 +2,4 @@
 "astro-lilypond": patch
 ---
 
-Serialize rendering to prevent race conditions when multiple lilypond processes run at once"
+Serialize rendering to prevent race conditions when multiple lilypond processes run at once.

--- a/.changeset/dry-snakes-greet.md
+++ b/.changeset/dry-snakes-greet.md
@@ -1,0 +1,5 @@
+---
+"astro-lilypond": patch
+---
+
+Serialize rendering to prevent race conditions when multiple lilypond processes run at once"

--- a/.changeset/thin-years-nail.md
+++ b/.changeset/thin-years-nail.md
@@ -1,0 +1,13 @@
+---
+"astro-lilypond": minor
+---
+
+Update rendering to use `<img>` tags for all content, including `.svg`. Previously, svg scores were inlined in the page. However, the `cairo`-based backend renderer makes heavy use of SVG's `<use>` element. When inlined on the page, these `<use>` tags can conflict with one another across scores, corrupting the display of notation. To avoid this, SVG elements are now rendered within an `<img>` tag. This has the benefit of reducing the number of HTML nodes on the page, but the drawback of no longer being able to inherit `currentColor` for noteheads. Given that the desire for inverted staff paper is unusual (and for many people, likely undesirable), this feels like an acceptable tradeoff.
+
+To prevent scores from displaying as black-on-black when in dark mode, add global styles to `.lilypond`:
+
+```css
+.lilypond {
+  background-color: white;
+}
+```

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,13 +41,6 @@ jobs:
       - name: Add LilyPond to PATH
         run: echo "$HOME/lilypond-2.26.0/bin" >> "$GITHUB_PATH"
 
-      - name: Warm LilyPond font cache
-        # Force fontconfig to build its cache before attempting to render examples
-        # to prevent malformatted glyphs/fonts from displaying on the scores
-        run: |
-          echo '\version "2.26.0" { c4 }' > /tmp/warmup.ly
-          lilypond --define-default=backend=cairo --output=/tmp/warmup /tmp/warmup.ly
-
       - name: Build library
         run: pnpm --filter astro-lilypond build
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -17,6 +17,9 @@ export default defineConfig({
       plugins: [starlightThemeFlexoki({
         accentColor: "green"
       })],
+      customCss: [
+        './src/styles/docs.css',
+      ],
       expressiveCode: {
         shiki: {
           langs: [lilypondGrammar],

--- a/docs/src/components/examples/StyledMusicExample.astro
+++ b/docs/src/components/examples/StyledMusicExample.astro
@@ -7,7 +7,7 @@ import score from "./scores/example.ly";
 
 <style>
   .score {
-    color: darkred;
     background: antiquewhite;
+    padding: 20px;
   }
 </style>

--- a/docs/src/content/docs/styling.mdx
+++ b/docs/src/content/docs/styling.mdx
@@ -7,20 +7,18 @@ import { Code } from "@astrojs/starlight/components";
 import StyledMusicExample from "../../components/examples/StyledMusicExample.astro";
 import StyledMusicExampleRaw from "../../components/examples/StyledMusicExample.astro?raw";
 
-Every rendered LilyPond block receives a `lilypond` class on its root element — an `<svg>` for SVG output or an `<img>` for PNG output. Use this class as your CSS hook.
+Every rendered LilyPond block receives a `lilypond` class on an `<img>` element. Use this class as your CSS hook.
 
 ## Global styles
 
-Target `.lilypond` in any global stylesheet:
+Target `.lilypond` in any global stylesheet to add a background or padding, for example:
 
 ```css
 .lilypond {
-  color: navy;
   background: ivory;
+  padding: 20px;
 }
 ```
-
-By default, LilyPond SVGs use `currentColor`, so the `color` property controls the notation colour and inherits from the surrounding text if unset.
 
 ## Scoped styles
 

--- a/docs/src/styles/docs.css
+++ b/docs/src/styles/docs.css
@@ -1,0 +1,8 @@
+.lilypond {
+  /* From starlight-theme-flexoki */
+  background: var(--color-paper);
+}
+
+[data-theme="dark"] .lilypond {
+  padding: 5%;
+}

--- a/package/src/render.ts
+++ b/package/src/render.ts
@@ -6,6 +6,20 @@ import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
 
+// Concurrent `lilypond` processes can race over shared, lazily-populated
+// caches, corrupting the output. Serialize invocations of the binary so
+// no two processes build at once.
+let invocationQueue: Promise<void> = Promise.resolve();
+
+function runExclusive<T>(task: () => Promise<T>): Promise<T> {
+	const result = invocationQueue.then(task, task);
+	invocationQueue = result.then(
+		() => undefined,
+		() => undefined,
+	);
+	return result;
+}
+
 const FORMATS = ["png", "svg"] as const;
 
 export type Format = (typeof FORMATS)[number];
@@ -102,7 +116,7 @@ export async function render(
 		// but let the exit code (not stderr content) decide pass/fail.
 		let stderr: string;
 		try {
-			({ stderr } = await execFileAsync(binaryPath, args));
+			({ stderr } = await runExclusive(() => execFileAsync(binaryPath, args)));
 		} catch (err) {
 			const errStderr =
 				err && typeof err === "object" && "stderr" in err

--- a/package/src/render.ts
+++ b/package/src/render.ts
@@ -6,20 +6,6 @@ import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
 
-// Concurrent `lilypond` processes can encounter race conditions
-// and corrupt the output. Serialize invocations of the binary so
-// no two processes build at once.
-let invocationQueue: Promise<void> = Promise.resolve();
-
-function runExclusive<T>(task: () => Promise<T>): Promise<T> {
-	const result = invocationQueue.then(task, task);
-	invocationQueue = result.then(
-		() => undefined,
-		() => undefined,
-	);
-	return result;
-}
-
 const FORMATS = ["png", "svg"] as const;
 
 export type Format = (typeof FORMATS)[number];
@@ -116,7 +102,7 @@ export async function render(
 		// but let the exit code (not stderr content) decide pass/fail.
 		let stderr: string;
 		try {
-			({ stderr } = await runExclusive(() => execFileAsync(binaryPath, args)));
+			({ stderr } = await execFileAsync(binaryPath, args));
 		} catch (err) {
 			const errStderr =
 				err && typeof err === "object" && "stderr" in err

--- a/package/src/render.ts
+++ b/package/src/render.ts
@@ -6,8 +6,8 @@ import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
 
-// Concurrent `lilypond` processes can race over shared, lazily-populated
-// caches, corrupting the output. Serialize invocations of the binary so
+// Concurrent `lilypond` processes can encounter race conditions
+// and corrupt the output. Serialize invocations of the binary so
 // no two processes build at once.
 let invocationQueue: Promise<void> = Promise.resolve();
 

--- a/package/src/util.ts
+++ b/package/src/util.ts
@@ -44,11 +44,16 @@ export function sourceNameFor(source: string | URL | null | undefined): string |
 	return basename(path);
 }
 
-/** Converts a rendered LilyPond buffer to an HTML string suitable for inline embedding. */
+const MIME_TYPES = {
+	svg: "image/svg+xml",
+	png: "image/png",
+} as const;
+
+/**
+ * Converts a rendered LilyPond buffer to an HTML string suitable for
+ * embedding.
+ */
 export function renderToHtml(buf: Buffer, format: "svg" | "png"): string {
-	if (format === "png") {
-		const b64 = buf.toString("base64");
-		return `<img class="lilypond" src="data:image/png;base64,${b64}" alt="LilyPond notation">`;
-	}
-	return buf.toString("utf-8").replace(/<svg\b/, '<svg class="lilypond"');
+	const b64 = buf.toString("base64");
+	return `<img class="lilypond" src="data:${MIME_TYPES[format]};base64,${b64}" alt="">`;
 }

--- a/package/tests/unit/rehype-plugin.test.ts
+++ b/package/tests/unit/rehype-plugin.test.ts
@@ -11,8 +11,9 @@ import { rehypeLilypondPlugin } from "../../src/rehype-plugin";
 const mockRender = vi.mocked(render);
 
 const FAKE_SVG = "<svg xmlns='http://www.w3.org/2000/svg'><g>fake</g></svg>";
-const RENDERED_SVG =
-	"<svg class=\"lilypond\" xmlns='http://www.w3.org/2000/svg'><g>fake</g></svg>";
+const RENDERED_SVG = `<img class="lilypond" src="data:image/svg+xml;base64,${Buffer.from(
+	FAKE_SVG,
+).toString("base64")}" alt="LilyPond notation">`;
 
 beforeEach(() => {
 	vi.clearAllMocks();
@@ -90,7 +91,7 @@ describe("rehypeLilypondPlugin", () => {
 		expect(typeof rehypeLilypondPlugin()).toBe("function");
 	});
 
-	it("transforms <pre><code.language-lilypond> to a raw SVG node", async () => {
+	it("transforms <pre><code.language-lilypond> to a raw img node", async () => {
 		const tree = makeTree([makeLilypondPre("\\score { }")]);
 
 		await runPlugin(tree);

--- a/package/tests/unit/rehype-plugin.test.ts
+++ b/package/tests/unit/rehype-plugin.test.ts
@@ -13,7 +13,7 @@ const mockRender = vi.mocked(render);
 const FAKE_SVG = "<svg xmlns='http://www.w3.org/2000/svg'><g>fake</g></svg>";
 const RENDERED_SVG = `<img class="lilypond" src="data:image/svg+xml;base64,${Buffer.from(
 	FAKE_SVG,
-).toString("base64")}" alt="LilyPond notation">`;
+).toString("base64")}" alt="">`;
 
 beforeEach(() => {
 	vi.clearAllMocks();

--- a/package/tests/unit/remark-plugin.test.ts
+++ b/package/tests/unit/remark-plugin.test.ts
@@ -15,8 +15,9 @@ import {
 const mockRender = vi.mocked(render);
 
 const FAKE_SVG = "<svg xmlns='http://www.w3.org/2000/svg'><g>fake</g></svg>";
-const RENDERED_SVG =
-	"<svg class=\"lilypond\" xmlns='http://www.w3.org/2000/svg'><g>fake</g></svg>";
+const RENDERED_SVG = `<img class="lilypond" src="data:image/svg+xml;base64,${Buffer.from(
+	FAKE_SVG,
+).toString("base64")}" alt="LilyPond notation">`;
 
 type SimpleTransformer = (tree: Root, file: { path: string }) => Promise<void>;
 type SimplePlugin = (opts?: RemarkPluginOptions) => SimpleTransformer;
@@ -43,7 +44,7 @@ describe("remarkLilypondPlugin", () => {
 		expect(typeof transformer).toBe("function");
 	});
 
-	it("transforms a lilypond code block to an html node with inline SVG", async () => {
+	it("transforms a lilypond code block to an html node with an svg img tag", async () => {
 		const tree = makeTree([
 			{ type: "code", lang: "lilypond", value: "\\score { }" } as Code,
 		]);

--- a/package/tests/unit/remark-plugin.test.ts
+++ b/package/tests/unit/remark-plugin.test.ts
@@ -17,7 +17,7 @@ const mockRender = vi.mocked(render);
 const FAKE_SVG = "<svg xmlns='http://www.w3.org/2000/svg'><g>fake</g></svg>";
 const RENDERED_SVG = `<img class="lilypond" src="data:image/svg+xml;base64,${Buffer.from(
 	FAKE_SVG,
-).toString("base64")}" alt="LilyPond notation">`;
+).toString("base64")}" alt="">`;
 
 type SimpleTransformer = (tree: Root, file: { path: string }) => Promise<void>;
 type SimplePlugin = (opts?: RemarkPluginOptions) => SimpleTransformer;

--- a/package/tests/unit/satteri-plugin.test.ts
+++ b/package/tests/unit/satteri-plugin.test.ts
@@ -14,7 +14,7 @@ const mockRender = vi.mocked(render);
 const FAKE_SVG = "<svg xmlns='http://www.w3.org/2000/svg'><g>fake</g></svg>";
 const RENDERED_SVG = `<img class="lilypond" src="data:image/svg+xml;base64,${Buffer.from(
 	FAKE_SVG,
-).toString("base64")}" alt="LilyPond notation">`;
+).toString("base64")}" alt="">`;
 
 beforeEach(() => {
 	vi.clearAllMocks();

--- a/package/tests/unit/satteri-plugin.test.ts
+++ b/package/tests/unit/satteri-plugin.test.ts
@@ -12,8 +12,9 @@ import { satteriLilypondPlugin } from "../../src/satteri-plugin.js";
 const mockRender = vi.mocked(render);
 
 const FAKE_SVG = "<svg xmlns='http://www.w3.org/2000/svg'><g>fake</g></svg>";
-const RENDERED_SVG =
-	"<svg class=\"lilypond\" xmlns='http://www.w3.org/2000/svg'><g>fake</g></svg>";
+const RENDERED_SVG = `<img class="lilypond" src="data:image/svg+xml;base64,${Buffer.from(
+	FAKE_SVG,
+).toString("base64")}" alt="LilyPond notation">`;
 
 beforeEach(() => {
 	vi.clearAllMocks();
@@ -27,7 +28,7 @@ describe("satteriLilypondPlugin", () => {
 		expect(typeof plugin.code).toBe("function");
 	});
 
-	it("transforms a lilypond code node to an html node with inline SVG", async () => {
+	it("transforms a lilypond code node to an html node with an svg img tag", async () => {
 		const plugin = satteriLilypondPlugin();
 		const node: Code = { type: "code", lang: "lilypond", value: "\\score { }" };
 


### PR DESCRIPTION
#21 introduced a regression when there were multiple SVG scores on the same page:

I made prior attempts to fix this (#25, #26) which were not the root of the problem. This PR removes those incorrect fixes and addresses the actual problem.

SVGs generated by the Cairo backend make heavy use of the `<use>` element for displaying notes and text. When more than one SVG is on the page, these `<use>` elements conflict, resulting in garbled scores:

<img width="1546" height="530" alt="CleanShot 2026-07-16 at 18 55 09@2x" src="https://github.com/user-attachments/assets/71ac3a63-9b99-4356-ae17-f48b5cd15d8e" />

(Here, for example, the score is displaying letters from "Jesu, meine Freunde", which are in the title of the preceding score.)

To avoid this, all scores are now rendered within `<img>` tags. This has the benefit of reducing the number of HTML nodes on the page, but the drawback of no longer being able to inherit `currentColor` for noteheads. Given that the desire for inverted staff paper is unusual (and for many people, likely undesirable), this feels like an acceptable tradeoff.

Fixes #19 which is resolved with the Cairo backend. Fonts also look better!