### PR TITLE
Run `convert-ly` on all examples to update to latest version

### DIFF
--- a/docs/src/components/examples/scores/ancient-headword.ly
+++ b/docs/src/components/examples/scores/ancient-headword.ly
@@ -1,4 +1,4 @@
-\version "2.25.5"
+\version "2.26.0"
 
 #(set-global-staff-size 23)
 

--- a/docs/src/components/examples/scores/aucun-snippet.ly
+++ b/docs/src/components/examples/scores/aucun-snippet.ly
@@ -1,4 +1,4 @@
-\version "2.25.28"
+\version "2.26.0"
 \include "example-header.ily"
 
 \paper {

--- a/docs/src/components/examples/scores/bach-bwv610.ly
+++ b/docs/src/components/examples/scores/bach-bwv610.ly
@@ -1,4 +1,4 @@
-\version "2.21.0"
+\version "2.26.0"
 
 \header {
   mutopiatitle = "Jesu, meine Freude"

--- a/docs/src/components/examples/scores/bach-invention.ly
+++ b/docs/src/components/examples/scores/bach-invention.ly
@@ -1,4 +1,4 @@
-\version "2.11.46"
+\version "2.26.0"
 
 voiceone =
 \relative c' {

--- a/docs/src/components/examples/scores/bach-schenker.ly
+++ b/docs/src/components/examples/scores/bach-schenker.ly
@@ -1,4 +1,4 @@
-\version "2.19.21"
+\version "2.26.0"
 
 \header{
   composer = "J.S. Bach"

--- a/docs/src/components/examples/scores/cary.ly
+++ b/docs/src/components/examples/scores/cary.ly
@@ -1,4 +1,4 @@
-\version "2.17.30"
+\version "2.26.0"
 \include "english.ly"
 
 % \header {

--- a/docs/src/components/examples/scores/chart.ly
+++ b/docs/src/components/examples/scores/chart.ly
@@ -1,4 +1,4 @@
-\version "2.19.21"
+\version "2.26.0"
 \include "example-header.ily"
 \include "predefined-guitar-fretboards.ly"
 

--- a/docs/src/components/examples/scores/granados.ly
+++ b/docs/src/components/examples/scores/granados.ly
@@ -3,7 +3,7 @@
 % Goyescas, "Coloquio en la Reja."              %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\version "2.25.34"
+\version "2.26.0"
 
 #(set-global-staff-size 14)
 

--- a/docs/src/components/examples/scores/orchestra.ly
+++ b/docs/src/components/examples/scores/orchestra.ly
@@ -1,4 +1,4 @@
-\version "2.25.80"
+\version "2.26.0"
 
 \header {
   tagline = ##f

--- a/docs/src/components/examples/scores/sesto-full.ly
+++ b/docs/src/components/examples/scores/sesto-full.ly
@@ -4,7 +4,7 @@
 %%%
 %%% Nicolas Sceaux <nicolas.sceaux@free.fr>
 
-\version "2.19.2"
+\version "2.26.0"
 \include "sesto.ily"
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/docs/src/components/examples/scores/sesto-piano.ly
+++ b/docs/src/components/examples/scores/sesto-piano.ly
@@ -4,7 +4,7 @@
 %%%
 %%% Nicolas Sceaux <nicolas.sceaux@free.fr>
 
-\version "2.21.0"
+\version "2.26.0"
 \include "sesto.ily"
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/docs/src/components/examples/scores/sesto-violin.ly
+++ b/docs/src/components/examples/scores/sesto-violin.ly
@@ -4,7 +4,7 @@
 %%%
 %%% Nicolas Sceaux <nicolas.sceaux@free.fr>
 
-\version "2.16.0"
+\version "2.26.0"
 \include "sesto.ily"
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/docs/src/components/examples/scores/stockhausen-klavierstueckII.ly
+++ b/docs/src/components/examples/scores/stockhausen-klavierstueckII.ly
@@ -1,4 +1,4 @@
-\version "2.25.35"
+\version "2.26.0"
 
 \paper {
   tagline = ##f

--- a/docs/src/components/examples/scores/tab-example.ly
+++ b/docs/src/components/examples/scores/tab-example.ly
@@ -1,4 +1,4 @@
-\version "2.19.21"
+\version "2.26.0"
 
 #(define (glissando::calc-extra-dy grob)
    (let* ((original (ly:grob-original grob))

--- a/docs/src/components/examples/scores/theory.ly
+++ b/docs/src/components/examples/scores/theory.ly
@@ -1,4 +1,4 @@
-\version "2.19.21"
+\version "2.26.0"
 \include "example-header.ily"
 
 #(ly:set-option 'point-and-click #f)


### PR DESCRIPTION
Run the `convert-ly` command line tool on all `.ly` examples to automatically update them to the latest versions. No issues recorded. Visually confirmed changes in the docs and everything looks good.