### PR TITLE
fix: TypeScript 'cannot find module' import errors

### DIFF
--- a/.changeset/old-games-dream.md
+++ b/.changeset/old-games-dream.md
@@ -1,0 +1,5 @@
+---
+"astro-lilypond": patch
+---
+
+Fix `Cannot find module` TypeScript errors on `.ly`/`.lilypond`/`.ily` imports using the `?crop` or `?nocrop` query suffix.

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,13 +1,13 @@
 {
 	"code_actions_on_format": {
-		"source.action.useSortedProperties.biome": true,
 		"source.fixAll.biome": true
 	},
 	"languages": {
 		"CSS": {
 			"formatter": { "language_server": { "name": "biome" } },
 			"code_actions_on_format": {
-				"source.fixAll.biome": true
+				"source.fixAll.biome": true,
+				"source.action.useSortedProperties.biome": true
 			}
 		},
 		"JavaScript": {
@@ -29,6 +29,25 @@
 			"code_actions_on_format": {
 				"source.fixAll.biome": true,
 				"source.organizeImports.biome": true
+			}
+		},
+		"Astro": {
+			"formatter": { "language_server": { "name": "biome" } },
+			"code_actions_on_format": {
+				"source.fixAll.biome": true,
+				"source.organizeImports.biome": true
+			}
+		},
+		"JSON": {
+			"formatter": { "language_server": { "name": "biome" } },
+			"code_actions_on_format": {
+				"source.fixAll.biome": true
+			}
+		},
+		"JSONC": {
+			"formatter": { "language_server": { "name": "biome" } },
+			"code_actions_on_format": {
+				"source.fixAll.biome": true
 			}
 		}
 	}

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,35 @@
+{
+	"code_actions_on_format": {
+		"source.action.useSortedProperties.biome": true,
+		"source.fixAll.biome": true
+	},
+	"languages": {
+		"CSS": {
+			"formatter": { "language_server": { "name": "biome" } },
+			"code_actions_on_format": {
+				"source.fixAll.biome": true
+			}
+		},
+		"JavaScript": {
+			"formatter": { "language_server": { "name": "biome" } },
+			"code_actions_on_format": {
+				"source.fixAll.biome": true,
+				"source.organizeImports.biome": true
+			}
+		},
+		"TypeScript": {
+			"formatter": { "language_server": { "name": "biome" } },
+			"code_actions_on_format": {
+				"source.fixAll.biome": true,
+				"source.organizeImports.biome": true
+			}
+		},
+		"TSX": {
+			"formatter": { "language_server": { "name": "biome" } },
+			"code_actions_on_format": {
+				"source.fixAll.biome": true,
+				"source.organizeImports.biome": true
+			}
+		}
+	}
+}

--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,8 @@
 		"enabled": true,
 		"actions": {
 			"source": {
-				"organizeImports": "on"
+				"organizeImports": "on",
+				"useSortedProperties": "on"
 			}
 		}
 	},

--- a/docs/src/components/examples/StyledMusicExample.astro
+++ b/docs/src/components/examples/StyledMusicExample.astro
@@ -7,8 +7,19 @@ import score from "./scores/example.ly?crop";
 <LilyPond content={score} class="styled" />
 
 <style>
+  @keyframes rainbow {
+    from {
+      filter: hue-rotate(0deg);
+    }
+    to {
+      filter: hue-rotate(360deg);
+    }
+  }
+
   .styled {
-    background: antiquewhite;
-    padding: 20px;
+    animation: rainbow 3s infinite;
+    background-color: moccasin;
+    border-radius: 5px;
+    padding: 5px;
   }
 </style>

--- a/docs/src/content/docs/styling.mdx
+++ b/docs/src/content/docs/styling.mdx
@@ -75,25 +75,27 @@ If you'd like to display multi-page scores in a horizontally-scrolling group lik
 
 <BachInventionExample />
 
-...here's the CSS to use:
+...here's a good baseline to start from:
 
 ```css
 [data-lilypond-group] {
-  list-style-type: none;
-  padding: 0;
-  display: flex;
-  overflow-x: auto;
-  gap: 1rem;
+	display: flex;
+	gap: 1rem;
+	padding: 0;
+	overflow-x: auto;
+	scroll-snap-type: x mandatory;
+	list-style-type: none;
 
-  li {
-    flex-shrink: 0;
-    margin: 0;
-  }
+	li {
+		flex-shrink: 0;
+		max-width: 80vw;
+		margin: 0;
+	}
 
-  img {
-    width: 100%;
-    border: 1px solid rgba(0, 0, 0, 0.1);
-    margin: 0;
-  }
+	img {
+		width: 100%;
+		margin: 0;
+		border: 1px solid rgba(0, 0, 0, 0.1);
+	}
 }
 ```

--- a/docs/src/content/docs/usage.mdx
+++ b/docs/src/content/docs/usage.mdx
@@ -109,7 +109,7 @@ import bachInvention from "./bach-invention.ly";
 
 #### `content`
 
-**Type:** `LilypondContent` (`{ pages: { src: string; width?: number; height?: number }[] }`)  
+**Type:** `LilypondContent`  
 **Required:** yes
 
 The result of an imported `.ly` or `.ily` file. The output is resolved at build time according to the `defaults` configured in your integration.

--- a/docs/src/styles/docs.css
+++ b/docs/src/styles/docs.css
@@ -3,22 +3,29 @@
 	background: var(--color-paper, #fffcf0);
 }
 
+[data-theme="dark"] [data-lilypond-image] {
+	padding: 5px;
+	border-radius: 5px;
+}
+
 [data-lilypond-group] {
-	list-style-type: none;
-	padding: 0;
 	display: flex;
-	overflow-x: auto;
 	gap: 1rem;
+	padding: 0;
+	overflow-x: auto;
+	list-style-type: none;
+	scroll-snap-type: x mandatory;
 
 	li {
 		flex-shrink: 0;
+		max-width: 80vw;
 		margin: 0;
 	}
 
 	img {
 		width: 100%;
-		border: 1px solid rgba(0, 0, 0, 0.1);
 		margin: 0;
+		border: 1px solid rgba(0, 0, 0, 0.1);
 	}
 }
 

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -3,5 +3,5 @@
 	"compilerOptions": {
 		"moduleResolution": "bundler"
 	},
-	"include": ["./worker-configuration.d.ts"]
+	"include": [".astro/types.d.ts", "**/*", "./worker-configuration.d.ts"]
 }

--- a/package/src/index.test.ts
+++ b/package/src/index.test.ts
@@ -353,14 +353,16 @@ describe("lilypond integration", () => {
 		expect(injectTypes.mock.calls[0][0].filename).toBe("ly-types.d.ts");
 	});
 
-	it("injected types declare modules for .ly, .lilypond, and .ily", () => {
+	it("injected types declare modules for .ly, .lilypond, and .ily, including their ?crop/?nocrop query variants", () => {
 		const injectTypes = vi.fn();
 		const integration = lilypond();
 		integration.hooks["astro:config:done"]?.({ injectTypes } as never);
 		const { content } = injectTypes.mock.calls[0][0] as { content: string };
-		expect(content).toContain('declare module "*.ly"');
-		expect(content).toContain('declare module "*.lilypond"');
-		expect(content).toContain('declare module "*.ily"');
+		for (const ext of [".ly", ".lilypond", ".ily"]) {
+			expect(content).toContain(`declare module "*${ext}"`);
+			expect(content).toContain(`declare module "*${ext}?crop"`);
+			expect(content).toContain(`declare module "*${ext}?nocrop"`);
+		}
 	});
 
 	it("injected type declarations export a default LilypondContent value", () => {
@@ -368,8 +370,8 @@ describe("lilypond integration", () => {
 		const integration = lilypond();
 		integration.hooks["astro:config:done"]?.({ injectTypes } as never);
 		const { content } = injectTypes.mock.calls[0][0] as { content: string };
-		expect(content.match(/export default content/g)?.length).toBe(3);
-		expect(content.match(/LilypondContent/g)?.length).toBe(3);
+		expect(content.match(/export default content/g)?.length).toBe(9);
+		expect(content.match(/LilypondContent/g)?.length).toBe(9);
 	});
 
 	it("includes the detected processor name in the error", async () => {

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -26,6 +26,7 @@ import {
 	parseLyHeader,
 	parseLyImportQuery,
 	prependVersion,
+	RECOGNIZED_QUERY_PARAMS,
 	resolveDefaults,
 	sourceNameFor,
 	titleFor,
@@ -266,11 +267,17 @@ export default function lilypond(
 			},
 
 			"astro:config:done": ({ injectTypes }) => {
+				const suffixes = [
+					"",
+					...RECOGNIZED_QUERY_PARAMS.map((param) => `?${param}`),
+				];
 				injectTypes({
 					filename: "ly-types.d.ts",
-					content: LY_EXTENSIONS.map(
-						(ext) =>
-							`declare module "*${ext}" {\n  const content: import("astro-lilypond").LilypondContent;\n  export default content;\n}`,
+					content: LY_EXTENSIONS.flatMap((ext) =>
+						suffixes.map(
+							(suffix) =>
+								`declare module "*${ext}${suffix}" {\n  const content: import("astro-lilypond").LilypondContent;\n  export default content;\n}`,
+						),
 					).join("\n"),
 				});
 			},

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -23,6 +23,7 @@ import {
 	assetsUrlBaseFor,
 	contentHashFor,
 	includePathsFor,
+	lyTypeDeclarationsFor,
 	parseLyHeader,
 	parseLyImportQuery,
 	prependVersion,
@@ -267,18 +268,12 @@ export default function lilypond(
 			},
 
 			"astro:config:done": ({ injectTypes }) => {
-				const suffixes = [
-					"",
-					...RECOGNIZED_QUERY_PARAMS.map((param) => `?${param}`),
-				];
 				injectTypes({
 					filename: "ly-types.d.ts",
-					content: LY_EXTENSIONS.flatMap((ext) =>
-						suffixes.map(
-							(suffix) =>
-								`declare module "*${ext}${suffix}" {\n  const content: import("astro-lilypond").LilypondContent;\n  export default content;\n}`,
-						),
-					).join("\n"),
+					content: lyTypeDeclarationsFor(
+						LY_EXTENSIONS,
+						RECOGNIZED_QUERY_PARAMS,
+					),
 				});
 			},
 

--- a/package/src/utils/index.ts
+++ b/package/src/utils/index.ts
@@ -7,7 +7,10 @@ export type { ImageDimensions } from "./imageDimensions.js";
 export { imageDimensionsFor } from "./imageDimensions.js";
 export { includePathsFor } from "./includePathsFor.js";
 export { isLilypondLang } from "./isLilypondLang.js";
-export { parseLyImportQuery } from "./lyImportQuery.js";
+export {
+	parseLyImportQuery,
+	RECOGNIZED_QUERY_PARAMS,
+} from "./lyImportQuery.js";
 export { contentTypeFor, isOwnAssetFileName } from "./ownAssetFileName.js";
 export { parseFenceMeta } from "./parseFenceMeta.js";
 export type { LyHeaderFields } from "./parseLyHeader.js";

--- a/package/src/utils/index.ts
+++ b/package/src/utils/index.ts
@@ -11,6 +11,7 @@ export {
 	parseLyImportQuery,
 	RECOGNIZED_QUERY_PARAMS,
 } from "./lyImportQuery.js";
+export { lyTypeDeclarationsFor } from "./lyTypeDeclarationsFor.js";
 export { contentTypeFor, isOwnAssetFileName } from "./ownAssetFileName.js";
 export { parseFenceMeta } from "./parseFenceMeta.js";
 export type { LyHeaderFields } from "./parseLyHeader.js";

--- a/package/src/utils/lyImportQuery.ts
+++ b/package/src/utils/lyImportQuery.ts
@@ -1,5 +1,7 @@
 /** Query params `lyFilePlugin` recognizes as its own on a `.ly`-family import. */
-const RECOGNIZED_PARAMS = new Set(["crop", "nocrop"]);
+export const RECOGNIZED_QUERY_PARAMS = ["crop", "nocrop"] as const;
+
+const RECOGNIZED_PARAMS = new Set<string>(RECOGNIZED_QUERY_PARAMS);
 
 export interface LyImportQuery {
 	/** The import's module id with any query string stripped. */

--- a/package/src/utils/lyTypeDeclarationsFor.test.ts
+++ b/package/src/utils/lyTypeDeclarationsFor.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { lyTypeDeclarationsFor } from "./lyTypeDeclarationsFor.js";
+
+describe("lyTypeDeclarationsFor", () => {
+	it("declares a bare module for each extension", () => {
+		const content = lyTypeDeclarationsFor([".ly", ".ily"], []);
+		expect(content).toContain('declare module "*.ly"');
+		expect(content).toContain('declare module "*.ily"');
+	});
+
+	it("declares a module per extension for each query param", () => {
+		const content = lyTypeDeclarationsFor([".ly"], ["crop", "nocrop"]);
+		expect(content).toContain('declare module "*.ly?crop"');
+		expect(content).toContain('declare module "*.ly?nocrop"');
+	});
+
+	it("each declaration exports a default LilypondContent value", () => {
+		const content = lyTypeDeclarationsFor(
+			[".ly", ".lilypond", ".ily"],
+			["crop", "nocrop"],
+		);
+		expect(content.match(/export default content/g)?.length).toBe(9);
+		expect(content.match(/LilypondContent/g)?.length).toBe(9);
+	});
+});

--- a/package/src/utils/lyTypeDeclarationsFor.ts
+++ b/package/src/utils/lyTypeDeclarationsFor.ts
@@ -1,0 +1,20 @@
+/**
+ * Builds the ambient module declarations injected for `.ly`-family imports,
+ * so `import content from "./score.ly"` (and its `?crop`/`?nocrop` query
+ * variants) type-check as a default-exported `LilypondContent`.
+ */
+export function lyTypeDeclarationsFor(
+	extensions: readonly string[],
+	queryParams: readonly string[],
+): string {
+	const suffixes = ["", ...queryParams.map((param) => `?${param}`)];
+
+	return extensions
+		.flatMap((ext) =>
+			suffixes.map(
+				(suffix) =>
+					`declare module "*${ext}${suffix}" {\n  const content: import("astro-lilypond").LilypondContent;\n  export default content;\n}`,
+			),
+		)
+		.join("\n");
+}


### PR DESCRIPTION
- Fix `Cannot find module` TypeScript errors on `.ly`/`.lilypond`/`.ily` imports using the `?crop` or `?nocrop` query suffix.
- Add `.zed` config folder
- Sort CSS properties
- Updated the `.styled` example
- Add small amount of padding and border radius to docs examples in dark mode