### PR TITLE
Add `<Score>` component

### DIFF
--- a/.changeset/tame-schools-yawn.md
+++ b/.changeset/tame-schools-yawn.md
@@ -1,0 +1,44 @@
+---
+"astro-lilypond": minor
+---
+
+Add a `<Score>` component for the common case of just displaying a score, without needing to call `render()` from frontmatter:
+
+```astro
+---
+import { Score } from "astro-lilypond";
+import bachInvention from "./bach-invention.ly";
+---
+
+<Score content={bachInvention} />
+```
+
+If you're only using `render()` to get a `Score` to display (not `pageCount`, `meta`, `raw`, or `pdf`), you can drop the frontmatter call entirely:
+
+```diff
+  ---
+- import { render } from "astro-lilypond";
++ import { Score } from "astro-lilypond";
+  import bachInvention from "./bach-invention.ly";
+
+- const { Score } = await render(bachInvention, { crop: true });
+  ---
+
+- <Score />
++ <Score content={bachInvention} crop />
+```
+
+`render()` itself is unchanged and still the way to get `pageCount`, `meta`, `raw`, or a `pdf` link alongside the image.
+
+This also plays a similar role to the pre-v0.15 `<LilyPond>` component: both take your imported `.ly` file directly via a `content` prop, and both accept `pageLimit`, `class`, `style`, and `alt` props. `<Score>` additionally accepts `format` and `crop`, which previously required `render()`'s options:
+
+```diff
+  ---
+- import LilyPond from "astro-lilypond/component";
++ import { Score } from "astro-lilypond";
+  import bachInvention from "./bach-invention.ly";
+  ---
+
+- <LilyPond content={bachInvention} />
++ <Score content={bachInvention} />
+```

--- a/docs/src/components/examples/BachInventionExample.astro
+++ b/docs/src/components/examples/BachInventionExample.astro
@@ -1,8 +1,6 @@
 ---
-import { render } from "astro-lilypond";
+import { Score } from "astro-lilypond";
 import bachInvention from "./scores/bach-invention.ly";
-
-const { Score } = await render(bachInvention);
 ---
 
-<Score />
+<Score content={bachInvention} />

--- a/docs/src/components/examples/HowToUse.astro
+++ b/docs/src/components/examples/HowToUse.astro
@@ -1,10 +1,8 @@
 ---
-import { render } from "astro-lilypond";
+import { Score } from "astro-lilypond";
 import FencedLilyPond from "#components/FencedLilypond.astro";
 import score from "./scores/example.ly";
 import exampleRaw from "./scores/example.ly?raw";
-
-const { Score } = await render(score, { crop: true });
 ---
 
 <section>
@@ -16,7 +14,7 @@ const { Score } = await render(score, { crop: true });
   </div>
   <div>
     <p>&hellip;and it renders as music notation.</p>
-    <Score class="responsive" />
+    <Score content={score} crop class="responsive" />
   </div>
 </section>
 

--- a/docs/src/components/examples/UsageExample.astro
+++ b/docs/src/components/examples/UsageExample.astro
@@ -1,10 +1,8 @@
 ---
-import { render } from "astro-lilypond";
+import { Score } from "astro-lilypond";
 import FencedLilypond from "#components/FencedLilypond.astro";
 import score from "./scores/example.ly";
 import code from "./scores/example.ly?raw";
-
-const { Score } = await render(score, { crop: true });
 ---
 
 <FencedLilypond code={code} />
@@ -13,4 +11,4 @@ const { Score } = await render(score, { crop: true });
   The above text will be replaced with this image on your webpage:
 </p>
 
-<Score />
+<Score content={score} crop />

--- a/docs/src/content/docs/guides/component.mdx
+++ b/docs/src/content/docs/guides/component.mdx
@@ -11,7 +11,7 @@ When you have scores that are unwieldy to write directly in [Markdown](/guides/m
 
 ## Displaying scores
 
-To display a score, import and pass your `.ly` score to the `render()` function from `astro-lilypond`. `render()` will return a `<Score>` component to use in your HTML.
+To display a score, import your `.ly` file and pass it to `<Score>`'s `content` prop:
 
 <Code code={BachInventionExampleRaw} lang="astro" title="MyComponent.astro" />
 
@@ -20,30 +20,66 @@ To display a score, import and pass your `.ly` score to the `render()` function 
 When a score renders to more than one page, as above, the pages are wrapped in an ordered list element. You can style pages and containers however you want. See the [styling guide](/guides/styling/) for more examples.
 
 :::caution
-Only call `render()` from prerendered pages and components. `astro-lilypond` doesn't currently support on-demand rendering.
+Only use `<Score>` from prerendered pages and components. `astro-lilypond` doesn't currently support on-demand rendering.
 :::
 
 ## Cropping
 
-By default, `render()` outputs scores as full pages, preserving page sizes and margins set via the imported LilyPond file.
+By default, `<Score>` renders full pages, preserving page sizes and margins set via the imported LilyPond file.
 
-If you'd prefer _not_ to use full pages, and instead crop all content to a single, potentially large image, pass `crop: true`:
+If you'd prefer _not_ to use full pages, and instead crop all content to a single, potentially large image, pass `crop`:
 
-```astro title="CroppedScore.astro" {7}
+```astro title="CroppedScore.astro" {6}
 ---
-import { render } from "astro-lilypond";
+import { Score } from "astro-lilypond";
 import bachInvention from "./bach-invention.ly";
-
-const { Score } = await render(
-  bachInvention,
-  { crop: true }
-);
 ---
 
-<Score />
+<Score content={bachInvention} crop />
 ```
 
-## Displaying score metadata
+## Limiting rendered pages
+
+By default, `<Score>` renders every page. To show only an excerpt, pass a `pageLimit`:
+
+```astro title="PreviewScore.astro" {6}
+---
+import { Score } from "astro-lilypond";
+import bachInvention from "./bach-invention.ly";
+---
+
+<Score content={bachInvention} pageLimit={1} />
+```
+
+`pageLimit={1}` renders only the first page. `pageLimit={2}` renders the first two pages, etc. Passing a `pageLimit` larger than the number of available pages has no effect.
+
+## Alt text
+
+`<Score>` derives alt text automatically from the imported `.ly` file's `\header` block, displaying `alt="{title} by {composer}"`.
+
+Pass an `alt` prop to override the generated alt text with your own description:
+
+```astro title="MyComponent.astro" {6}
+---
+import { Score } from "astro-lilypond";
+import bachInvention from "./bach-invention.ly";
+---
+
+<Score
+  content={bachInvention}
+  alt="A piano score showing a two-part invention by Bach"
+/>
+```
+
+## Advanced usage with `render()`
+
+`<Score>` covers the common case — just showing a score. When you also need the
+score's page count, header metadata, raw source text, or a downloadable PDF
+alongside the image, call `render()` from frontmatter instead. It returns the
+same kind of `Score` component (accepting the same `pageLimit`, `class`,
+`style`, and `alt` props described above), plus those extras.
+
+### Displaying score metadata
 
 `render()`'s `meta` carries the fields parsed from the score's `\header` block, such as `title`, `composer`, and `opus`.
 
@@ -62,9 +98,9 @@ const { Score, meta } = await render(bachInvention);
 
 For a full list of metadata fields, see the [component reference](/reference/component/#lilypondmetadata-type).
 
-## PDF links
+### PDF links
 
-Pass `pdf: true` to generate a PDF file, returned as `pdf`:
+Pass `pdf: true` to generate a PDF file in addition to the `<Score>` images. The returned `pdf` can be used for download links by referencing `src`:
 
 ```astro title="ScoreWithDownload.astro" {5-8,12}
 ---
@@ -76,16 +112,12 @@ const { Score, pdf } = await render(
   { crop: true, pdf: true }
 );
 ---
-```
 
-The returned `pdf` can be used for download links by referencing `src`:
-
-```astro title="ScoreWithDownload.astro" {2}
 <Score />
 <a href={pdf.src} download>Download PDF</a>
 ```
 
-## Showing page counts
+### Showing page counts
 
 Display a rendered score's page count with `pageCount`, alongside `Score`:
 
@@ -101,7 +133,7 @@ const { Score, pageCount } = await render(bachInvention);
 <p>{pageCount} {pageCount === 1 ? "page" : "pages"}</p>
 ```
 
-## Outputting raw text
+### Outputting raw text
 
 `render()`'s `raw` returns your LilyPond source code as a string. Use it wherever you need to show the text itself, rather than the rendered image.
 
@@ -116,38 +148,4 @@ const { Score, raw } = await render(bachInvention);
 
 <Score />
 <Code code={raw} lang="lilypond" title="bach-invention.ly" />
-```
-
-## Limiting rendered pages
-
-By default, `<Score />` renders every page. To show only an excerpt, pass a `pageLimit`:
-
-```astro title="PreviewScore.astro" {8}
----
-import { render } from "astro-lilypond";
-import bachInvention from "./bach-invention.ly";
-
-const { Score } = await render(bachInvention);
----
-
-<Score pageLimit={1} />
-```
-
-`pageLimit={1}` renders only the first page. `pageLimit={2}` renders the first two pages, etc. Passing a `pageLimit` larger than the number of available pages has no effect.
-
-## Alt text
-
-`<Score />` derives alt text automatically from the imported `.ly` file's `\header` block, displaying `alt="{title} by {composer}"`.
-
-Pass an `alt` prop to override the generated alt text with your own description:
-
-```astro title="MyComponent.astro" {8}
----
-import { render } from "astro-lilypond";
-import bachInvention from "./bach-invention.ly";
-
-const { Score } = await render(bachInvention);
----
-
-<Score alt="A piano score showing a two-part invention by Bach" />
 ```

--- a/docs/src/content/docs/reference/component.mdx
+++ b/docs/src/content/docs/reference/component.mdx
@@ -1,11 +1,90 @@
 ---
 title: Component Reference
-description: Signature and types for the exported render() function, and the props Score accepts.
+description: Signature and types for the exported Score component and render() function.
 ---
 
-`render()`, imported from `astro-lilypond`, turns LilyPond code into a renderable `<Score />` component.
+`astro-lilypond` exports two ways to turn LilyPond code into rendered markup:
 
-## `render()` parameters
+- **[`<Score />`](#score-)** — a component for the common case: just display a score.
+- **[`render()`](#render)** — a function for when you also need `pageCount`, `meta`, `raw`, or a `pdf` link alongside the image.
+
+## `<Score />`
+
+```ts
+import { Score } from "astro-lilypond";
+
+interface ScoreProps {
+  content: LilypondScore;
+  format?: "svg" | "png"; // default "svg"
+  crop?: boolean; // default false
+  pageLimit?: number;
+  class?: string;
+  style?: string;
+  alt?: string;
+}
+```
+
+```astro title="MyComponent.astro"
+---
+import { Score } from "astro-lilypond";
+import bachInvention from "./bach-invention.ly";
+---
+
+<Score content={bachInvention} />
+```
+
+:::caution
+Only use `<Score />` from prerendered pages and components. `astro-lilypond` doesn't currently support on-demand rendering.
+:::
+
+### `content`
+
+**Type:** `LilypondScore`
+
+The score's source text and derived metadata. You get one from:
+
+- Importing a `.ly`/`.ily`/`.lilypond` file directly.
+- A [`lilypondLoader()`](/reference/collections/) content-collection entry; `entry.data` is a `LilypondScore`.
+
+### `format`
+
+**Type:** `"svg" | "png"`  
+**Default:** `"svg"`
+
+Output format for the rendered image.
+
+### `crop`
+
+**Type:** `boolean`  
+**Default:** `false`
+
+Crops the score to a single tightly-fit image instead of full pages — see [cropping](/guides/component/#cropping).
+
+### `pageLimit`
+
+**Type:** `number`
+
+Render only the first `n` pages. If omitted, all pages render. See [limiting rendered pages](/guides/component/#limiting-rendered-pages).
+
+### `class`
+
+**Type:** `string`
+
+Class name(s) applied to the rendered `<img>` (or `<ol>`, for multi-page scores). See the [styling guide](/guides/styling/).
+
+### `style`
+
+**Type:** `string`
+
+Inline styles applied directly to the rendered element.
+
+### `alt`
+
+**Type:** `string`
+
+Overrides the automatically-derived alt text. Takes precedence over any `title`/`composer` found in the `.ly` file's `\header` block. See also: [alt text](/guides/component/#alt-text).
+
+## `render()`
 
 ```ts
 import { render } from "astro-lilypond";
@@ -36,10 +115,7 @@ Only call `render()` from prerendered pages and components. `astro-lilypond` doe
 
 **Type:** `LilypondScore`
 
-The score's source text and derived metadata. You get one from:
-
-- Importing a `.ly`/`.ily`/`.lilypond` file directly.
-- A [`lilypondLoader()`](/reference/collections/) content-collection entry; `entry.data` is a `LilypondScore`.
+Same as [`<Score />`'s `content`](#content) above.
 
 ### `options`
 
@@ -82,7 +158,7 @@ const { Score, pdf, meta } = await render(
 <a href={pdf.src} download>Download PDF</a>
 ```
 
-See [`<Score /> props`](#score--props) below for what `Score` accepts, and [`LilypondMetadata`](#lilypondmetadata) for the shape of `meta`.
+`render()`'s returned `Score` accepts the same `pageLimit`, `class`, `style`, and `alt` props as [`<Score />`](#score-) above — everything except `content`, `format`, and `crop`, since those are already fixed by the call to `render()`.
 
 You can rename `Score` however you like when destructuring:
 
@@ -157,31 +233,3 @@ interface LilypondMetadata {
   [field: string]: string | undefined;
 }
 ```
-
-## `<Score />` props
-
-`Score` accepts the following props:
-
-### `pageLimit`
-
-**Type:** `number`
-
-Render only the first `n` pages. If omitted, all pages render. See [limiting rendered pages](/guides/component/#limiting-rendered-pages).
-
-### `class`
-
-**Type:** `string`
-
-Class name(s) applied to the rendered `<img>` (or `<ol>`, for multi-page scores). See the [styling guide](/guides/styling/).
-
-### `style`
-
-**Type:** `string`
-
-Inline styles applied directly to the rendered element.
-
-### `alt`
-
-**Type:** `string`
-
-Overrides the automatically-derived alt text. Takes precedence over any `title`/`composer` found in the `.ly` file's `\header` block. See also: [alt text](/guides/component/#alt-text).

--- a/package/src/__tests__/index.test.ts
+++ b/package/src/__tests__/index.test.ts
@@ -34,6 +34,7 @@ import { experimental_AstroContainer as AstroContainer } from "astro/container";
 import { resolveLilypondBinary } from "../binary/index.js";
 import lilypond, {
 	type LilypondScore,
+	Score as PublicScore,
 	render as publicRender,
 	renderAll as publicRenderAll,
 } from "../index.js";
@@ -763,6 +764,121 @@ describe("render()", () => {
 		await expect(publicRender(SCORE)).rejects.toThrow(
 			/lilypond\(\).*Astro config/s,
 		);
+	});
+});
+
+describe("Score component", () => {
+	const SCORE: LilypondScore = {
+		source: "\\score { }",
+		alt: "Sonata, by Beethoven",
+		sourceName: "score.ly",
+		includePaths: ["/docs/src"],
+		assetTitle: "score",
+		meta: { title: "Sonata", composer: "Beethoven" },
+	};
+
+	beforeEach(() => {
+		setRenderState({
+			binaryPath: "lilypond",
+			defaults: undefined,
+			timeout: undefined,
+		});
+	});
+
+	it("renders an <img> directly from content, with no render() call needed", async () => {
+		mockEmitLilypondAsset.mockResolvedValueOnce([{ src: "/_astro/a.svg" }]);
+		const container = await AstroContainer.create();
+		const html = await container.renderToString(PublicScore, {
+			props: { content: SCORE },
+		});
+		expect(html).toContain('src="/_astro/a.svg"');
+		expect(html).toContain("data-lilypond-image");
+		expect(html).toContain(`alt="${SCORE.alt}"`);
+	});
+
+	it("defaults to svg, uncropped", async () => {
+		const container = await AstroContainer.create();
+		await container.renderToString(PublicScore, { props: { content: SCORE } });
+		expect(mockEmitLilypondAsset.mock.calls[0][0]).toMatchObject({
+			format: "svg",
+			crop: false,
+		});
+	});
+
+	it("honors explicit format and crop props", async () => {
+		const container = await AstroContainer.create();
+		await container.renderToString(PublicScore, {
+			props: { content: SCORE, format: "png", crop: true },
+		});
+		expect(mockEmitLilypondAsset.mock.calls[0][0]).toMatchObject({
+			format: "png",
+			crop: true,
+		});
+	});
+
+	it("falls back to an empty alt when neither content nor props provide one", async () => {
+		mockEmitLilypondAsset.mockResolvedValueOnce([{ src: "/_astro/a.svg" }]);
+		const container = await AstroContainer.create();
+		const html = await container.renderToString(PublicScore, {
+			props: { content: { ...SCORE, alt: undefined as unknown as string } },
+		});
+		expect(html).toContain('src="/_astro/a.svg"');
+		expect(html).not.toContain(SCORE.alt);
+	});
+
+	it("prefers an explicit alt prop over content's alt", async () => {
+		mockEmitLilypondAsset.mockResolvedValueOnce([{ src: "/_astro/a.svg" }]);
+		const container = await AstroContainer.create();
+		const html = await container.renderToString(PublicScore, {
+			props: { content: SCORE, alt: "Custom alt" },
+		});
+		expect(html).toContain('alt="Custom alt"');
+		expect(html).not.toContain(SCORE.alt);
+	});
+
+	it("forwards class and style to the rendered markup", async () => {
+		mockEmitLilypondAsset.mockResolvedValueOnce([{ src: "/_astro/a.svg" }]);
+		const container = await AstroContainer.create();
+		const html = await container.renderToString(PublicScore, {
+			props: { content: SCORE, class: "extra", style: "width: 50%" },
+		});
+		expect(html).toContain('class="extra"');
+		expect(html).toContain('style="width: 50%"');
+	});
+
+	it("renders multiple pages as an <ol data-lilypond-group> of <li><img>s", async () => {
+		mockEmitLilypondAsset.mockResolvedValueOnce([
+			{ src: "/_astro/a.svg" },
+			{ src: "/_astro/b.svg" },
+		]);
+		const container = await AstroContainer.create();
+		const html = await container.renderToString(PublicScore, {
+			props: { content: SCORE },
+		});
+		expect(html).toContain("data-lilypond-group");
+		expect(html).toContain('src="/_astro/a.svg"');
+		expect(html).toContain('src="/_astro/b.svg"');
+	});
+
+	it("forwards pageLimit through, limiting rendered pages", async () => {
+		mockEmitLilypondAsset.mockResolvedValueOnce([
+			{ src: "/_astro/a.svg" },
+			{ src: "/_astro/b.svg" },
+		]);
+		const container = await AstroContainer.create();
+		const html = await container.renderToString(PublicScore, {
+			props: { content: SCORE, pageLimit: 1 },
+		});
+		expect(html).toContain('src="/_astro/a.svg"');
+		expect(html).not.toContain('src="/_astro/b.svg"');
+	});
+
+	it("throws the same actionable error as render() when the lilypond() integration hasn't run", async () => {
+		resetRenderStateForTests();
+		const container = await AstroContainer.create();
+		await expect(
+			container.renderToString(PublicScore, { props: { content: SCORE } }),
+		).rejects.toThrow(/lilypond\(\).*Astro config/s);
 	});
 });
 

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -2,6 +2,7 @@ import type { AstroIntegration } from "astro";
 import {
 	type AstroComponentFactory,
 	createComponent,
+	renderComponent,
 	renderTemplate,
 	unescapeHTML,
 } from "astro/runtime/server/index.js";
@@ -98,7 +99,7 @@ export interface RenderResult {
 	raw: string;
 }
 
-interface ScoreProps {
+interface ScoreImageProps {
 	pageLimit?: number;
 	class?: string;
 	style?: string;
@@ -108,7 +109,7 @@ interface ScoreProps {
 function createScoreComponent(
 	content: LilypondImageResult,
 ): AstroComponentFactory {
-	return createComponent((_result, props: ScoreProps) => {
+	return createComponent((_result, props: ScoreImageProps) => {
 		const alt = props.alt ?? content.alt ?? "";
 		const html = renderedHtml(content.pages, alt, {
 			class: props.class,
@@ -179,6 +180,37 @@ export async function render(
 
 	return { Score, pageCount, pdf, meta: score.meta, raw: score.source };
 }
+
+export interface ScoreProps extends ScoreImageProps {
+	/**
+	 * A `LilypondScore` from a `.ly`/`.ily`/`.lilypond` import
+	 * or a `lilypondLoader()` entry.
+	 */
+	content: LilypondScore;
+
+	/**
+	 * @default "svg"
+	 */
+	format?: "svg" | "png";
+
+	/**
+	 * @default false
+	 */
+	crop?: boolean;
+}
+
+/**
+ * Renders a `LilypondScore` directly, for the common case where none of
+ * `render()`'s `pageCount`, `meta`, `raw`, or `pdf` are needed. Use
+ * `render()` instead when you need those.
+ */
+export const Score: AstroComponentFactory = createComponent(
+	async (result, props: ScoreProps) => {
+		const { content, format, crop, ...imageProps } = props;
+		const { Score: ContentScore } = await render(content, { format, crop });
+		return renderTemplate`${renderComponent(result, "Score", ContentScore, imageProps)}`;
+	},
+);
 
 export async function renderAll(
 	scores: LilypondScore[],


### PR DESCRIPTION
- Add a simpler `<Score>` export from `astro-lilypond` for basic display cases