### PR TITLE
Fix overzealous CSS reset on error HTML

### DIFF
--- a/.changeset/breezy-months-mix.md
+++ b/.changeset/breezy-months-mix.md
@@ -1,0 +1,5 @@
+---
+"astro-lilypond": patch
+---
+
+Fix overzealous CSS reset on error blocks rendered in dev mode.

--- a/package/src/utils/__tests__/renderedErrorHtml.test.ts
+++ b/package/src/utils/__tests__/renderedErrorHtml.test.ts
@@ -30,7 +30,6 @@ describe("renderedErrorHtml", () => {
 
 	it("resets inherited styles before declaring its own", () => {
 		const html = renderedErrorHtml(new Error("x"), "score");
-		expect(html).toContain("all: initial");
 		expect(html).toContain("white-space: pre-wrap");
 	});
 });

--- a/package/src/utils/renderedErrorHtml.ts
+++ b/package/src/utils/renderedErrorHtml.ts
@@ -1,14 +1,19 @@
 import { escapeHtml } from "./escapeHtml.js";
 
-const ERROR_STYLE =
-	"all: initial; display: block; margin: 1em 0; padding: 1em; " +
-	"color-scheme: light dark; " +
-	"border: 2px solid light-dark(#dc2626, #f87171); border-radius: 6px; " +
-	"background: light-dark(#fef2f2, #450a0a); " +
-	"color: light-dark(#7f1d1d, #fca5a5); " +
-	"font-family: ui-monospace, monospace; " +
-	"font-size: 0.875rem; line-height: 1.5; white-space: pre-wrap; " +
-	"overflow-wrap: break-word; text-align: left;";
+const ERROR_STYLE = `display: block;
+   margin: 1em 0;
+   padding: 1em;
+   color-scheme: light dark;
+   border: 2px solid light-dark(#dc2626, #f87171);
+   border-radius: 6px;
+   background: light-dark(#fef2f2, #450a0a);
+   color: light-dark(#5d1516, #fcd1d2);
+   font-family: ui-monospace, monospace;
+   font-size: 0.875rem;
+   line-height: 1.5;
+   white-space: pre-wrap;
+   overflow-wrap: break-word;
+   text-align: left;`;
 
 function messageFor(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
The `all: initial` declaration was causing unintended side-effects when the error was rendered inside a flex or grid layout which depended on it inheriting certain layout attributes. Remove.