### PR TITLE
Remove trailing slashes from docs URLs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -11,6 +11,10 @@ export default defineConfig({
 		prerenderEnvironment: "node",
 		imageService: "passthrough",
 	}),
+	build: {
+		format: "file",
+	},
+	trailingSlash: "never",
 	integrations: [
 		lilypond({
 			defaults: {
@@ -97,7 +101,7 @@ export default defineConfig({
 						"about",
 						{
 							label: "Changelog",
-							link: "/changelog/",
+							link: "/changelog",
 						},
 						"resources/syntax",
 						"resources",

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -51,6 +51,13 @@ export default defineConfig({
 					},
 				},
 				{
+					tag: "meta",
+					attrs: {
+						name: "author",
+						content: "Ky Decker",
+					},
+				},
+				{
 					tag: "script",
 					attrs: {
 						src: "https://cdn.usefathom.com/script.js",

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -24,13 +24,13 @@ Here's how to get the `astro-lilypond` integration set up so you can begin writi
 
 3. Start writing music!
 
-   You can do a lot with LilyPond; view the [examples](/examples/). Write your LilyPond code directly in [Markdown](/guides/markdown/), or render `.ly` files with [`<Score>`](/guides/component/).
+   You can do a lot with LilyPond; view the [examples](/examples). Write your LilyPond code directly in [Markdown](/guides/markdown), or render `.ly` files with [`<Score>`](/guides/component).
 
 </Steps>
 
 ## Installing LilyPond (optional)
 
-When writing music locally, it's recommended to install the LilyPond binary so that you can compile scores in other tools. If the binary is unavailable (for example, when [building and deploying](/guides/deployment/) your site), `astro-lilypond` will install it automatically.
+When writing music locally, it's recommended to install the LilyPond binary so that you can compile scores in other tools. If the binary is unavailable (for example, when [building and deploying](/guides/deployment) your site), `astro-lilypond` will install it automatically.
 
 ### Download
 

--- a/docs/src/content/docs/guides/component.mdx
+++ b/docs/src/content/docs/guides/component.mdx
@@ -17,7 +17,7 @@ To display a score, import your `.ly` file and pass it to `<Score>`'s `content` 
 
 <BachInventionExample />
 
-When a score renders to more than one page, as above, the pages are wrapped in an ordered list element. You can style pages and containers however you want. See the [styling guide](/guides/styling/) for more examples.
+When a score renders to more than one page, as above, the pages are wrapped in an ordered list element. You can style pages and containers however you want. See the [styling guide](/guides/styling) for more examples.
 
 :::caution
 Only use `<Score>` from prerendered pages and components. `astro-lilypond` doesn't currently support on-demand rendering.

--- a/docs/src/content/docs/guides/markdown.mdx
+++ b/docs/src/content/docs/guides/markdown.mdx
@@ -14,7 +14,7 @@ Once you've installed `astro-lilypond`, you can write LilyPond code inside of an
 
 The markdown-based approach is great for small musical examples and excerpts which you want to write alongside prose. You can write your text, compose some music, and then switch back to text without leaving the file!
 
-For longer musical examples, you may want to use the [`<Score> component`](/guides/component/) instead.
+For longer musical examples, you may want to use the [`<Score> component`](/guides/component) instead.
 
 ## Alt text
 

--- a/docs/src/content/docs/guides/styling.mdx
+++ b/docs/src/content/docs/guides/styling.mdx
@@ -14,7 +14,7 @@ Every image is output to the page with this basic markup:
 <img src="..." data-lilypond-image />
 ```
 
-See the [styling reference](/reference/styling/) for a full list of available selectors.
+See the [styling reference](/reference/styling) for a full list of available selectors.
 
 ## Global styles
 
@@ -28,7 +28,7 @@ Target `[data-lilypond-image]` in any global stylesheet to modify global styles 
 
 ## Scoped styles
 
-The `<Score>` [component](/reference/component/)) accepts a `class` prop, scoped to that specific instance.
+The `<Score>` [component](/reference/component)) accepts a `class` prop, scoped to that specific instance.
 
 <Code code={StyledMusicExampleRaw} lang="astro" />
 

--- a/docs/src/content/docs/reference/component.mdx
+++ b/docs/src/content/docs/reference/component.mdx
@@ -37,7 +37,7 @@ import bachInvention from "./bach-invention.ly";
 The score's source text and derived metadata. You get one from:
 
 - Importing a `.ly`/`.ily`/`.lilypond` file directly.
-- A [`lilypondLoader()`](/reference/collections/) content-collection entry; `entry.data` is a `LilypondScore`.
+- A [`lilypondLoader()`](/reference/collections) content-collection entry; `entry.data` is a `LilypondScore`.
 
 ### `format`
 
@@ -63,7 +63,7 @@ Render only the first `n` pages. If omitted, all pages render. See [limiting ren
 
 **Type:** `string`
 
-Class name(s) applied to the rendered `<img>` (or `<ol>`, for multi-page scores). See the [styling guide](/guides/styling/).
+Class name(s) applied to the rendered `<img>` (or `<ol>`, for multi-page scores). See the [styling guide](/guides/styling).
 
 ### `style`
 

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -66,7 +66,7 @@ Downloads are cached per OS. The cache directory can be overridden with the `AST
 
 **Type:** `object`
 
-Default settings applied to every score, across Markdown fences, `.ly`/`.ily` imports, and [`lilypondLoader()`](/guides/collections/) entries alike. `version` can also be overridden per file with an explicit `\version` declaration; `format` can be overridden per call via [`getScore()`/`<Score>`](/reference/component/).
+Default settings applied to every score, across Markdown fences, `.ly`/`.ily` imports, and [`lilypondLoader()`](/guides/collections) entries alike. `version` can also be overridden per file with an explicit `\version` declaration; `format` can be overridden per call via [`getScore()`/`<Score>`](/reference/component).
 
 #### `defaults.cropScale`
 

--- a/docs/src/content/docs/reference/styling.mdx
+++ b/docs/src/content/docs/reference/styling.mdx
@@ -3,7 +3,7 @@ title: Styling Reference
 description: All the selectors astro-lilypond ships for styling rendered scores.
 ---
 
-The following reference lists all selectors which are attached to rendered output. `astro-lilypond` doesn't ship any styles of its own. See the [styling guide](/guides/styling/) for examples in-use.
+The following reference lists all selectors which are attached to rendered output. `astro-lilypond` doesn't ship any styles of its own. See the [styling guide](/guides/styling) for examples in-use.
 
 | Selector | Applies to |
 |---|---|

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -51,7 +51,7 @@ import HowToUse from "#components/examples/HowToUse.astro";
         Automatic <code>alt</code> text from the score's title and composer. (Or supply your own.)
       </Card>
       <Card title="Built-in content loader">
-        Pass in a folder full of <code>.ly</code> files, get back an Astro <a href="/guides/collections/">content collection</a> with metadata.
+        Pass in a folder full of <code>.ly</code> files, get back an Astro <a href="/guides/collections">content collection</a> with metadata.
       </Card>
       <Card title="Full LilyPond support">
         Works with all LilyPond syntax. Check out the <a href="/examples">examples</a> to see what's possible!


### PR DESCRIPTION
No trailing slashes. Add "author" meta tag.