### PR TITLE
Add `includePaths` config option

### DIFF
--- a/.changeset/include-paths-option.md
+++ b/.changeset/include-paths-option.md
@@ -1,0 +1,16 @@
+---
+"astro-lilypond": minor
+---
+
+Adds an `includePaths` config option to extend `\include` resolution with extra directories, in addition to each score's own directory.
+
+To enable, pass an array of directories to `includePaths` in the integration config:
+
+```js
+// astro.config.mjs
+lilypond({
+  includePaths: ["./src/snippets"],
+})
+```
+
+This will ensure that LilyPond has access to any styles, layouts, and helper definitions which are defined separately from the score itself.

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -66,7 +66,7 @@ Downloads are cached per OS. The cache directory can be overridden with the `AST
 
 **Type:** `object`
 
-Default settings applied to every score, across Markdown fences, `.ly`/`.ily` imports, and [`lilypondLoader()`](/guides/collections) entries alike. `version` can also be overridden per file with an explicit `\version` declaration; `format` can be overridden per call via [`getScore()`/`<Score>`](/reference/component).
+Default settings applied to every score. `version` can also be overridden per file with an explicit `\version` declaration; `format` can be overridden per call via [`getScore()`/`<Score>`](/reference/component).
 
 #### `defaults.cropScale`
 
@@ -89,7 +89,7 @@ lilypond({
 **Type:** `"svg" | "png"`  
 **Default:** `"svg"`
 
-The output format used for every score — Markdown fences, `.ly`/`.ily` imports, and `lilypondLoader()` entries alike.
+The output format used for every score.
 
 ```js
 // astro.config.mjs
@@ -136,3 +136,17 @@ LilyPond code with an explicit `\version` declaration will always use that versi
 :::tip
 LilyPond uses even numbers (like `2.26.0`) for stable releases and odd numbers (like `2.27.0`) for development releases. [View all LilyPond releases on GitLab.](https://gitlab.com/lilypond/lilypond/-/releases)
 :::
+
+### `includePaths`
+
+**Type:** `string[]`  
+**Default:** `[]`
+
+Extra directories LilyPond should search for files, in addition to each score's own directory (which is always searched automatically). Relative paths resolve against the project root. This setting is useful if you store shared styles, layouts, and helper definitions separately from your main scores.
+
+```js
+// astro.config.mjs
+lilypond({
+  includePaths: ["./src/snippets"],
+})
+```

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -151,8 +151,12 @@ lilypond({
 })
 ```
 
-Once configured, content from `includePaths` can be referenced in your `.ly` files:
+Once configured, content from `includePaths` can be referenced elsewhere:
 
 ```lilypondtext title="my-score.ly"
-\include "my-snippet.ly"
+\include "my-snippet.ily"
 ```
+
+:::tip
+It's customary to use the `.ily` file extension for _included_ snippets and the `.ly` extension for your scores.
+:::

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -150,3 +150,9 @@ lilypond({
   includePaths: ["./src/snippets"],
 })
 ```
+
+Once configured, content from `includesPaths` can be referenced in your `.ly` files:
+
+```lilypondtext title="my-score.ly"
+\include "my-snippet.ly"
+```

--- a/docs/src/content/docs/reference/configuration.mdx
+++ b/docs/src/content/docs/reference/configuration.mdx
@@ -151,7 +151,7 @@ lilypond({
 })
 ```
 
-Once configured, content from `includesPaths` can be referenced in your `.ly` files:
+Once configured, content from `includePaths` can be referenced in your `.ly` files:
 
 ```lilypondtext title="my-score.ly"
 \include "my-snippet.ly"

--- a/e2e/astro.config.satteri.mjs
+++ b/e2e/astro.config.satteri.mjs
@@ -11,6 +11,7 @@ export default defineConfig({
 				version: "2.26.0",
 				cropScale: 2,
 			},
+			includePaths: ["./src/snippets"],
 		}),
 		mdx(),
 	],

--- a/e2e/astro.config.unified.mjs
+++ b/e2e/astro.config.unified.mjs
@@ -15,6 +15,7 @@ export default defineConfig({
 				version: "2.26.0",
 				cropScale: 2,
 			},
+			includePaths: ["./src/snippets"],
 		}),
 		mdx(),
 	],

--- a/e2e/src/pages/score-include-paths.astro
+++ b/e2e/src/pages/score-include-paths.astro
@@ -1,0 +1,9 @@
+---
+import { Score } from "astro-lilypond";
+import BaseLayout from "../layouts/BaseLayout.astro";
+import hornPart from "../scores/horn-part.ly";
+---
+
+<BaseLayout title="Score: includePaths">
+	<Score content={hornPart} />
+</BaseLayout>

--- a/e2e/src/scores/horn-part.ly
+++ b/e2e/src/scores/horn-part.ly
@@ -1,5 +1,5 @@
-% e2e fixture: validates that the includePaths config option resolves
-% \include from ../snippets, a directory other than this file's own.
+% validate that the `includePaths` config option resolves
+% \include from ../snippets
 \include "horn-music.ly"
 
 \header {

--- a/e2e/src/scores/horn-part.ly
+++ b/e2e/src/scores/horn-part.ly
@@ -1,0 +1,12 @@
+% e2e fixture: validates that the includePaths config option resolves
+% \include from ../snippets, a directory other than this file's own.
+\include "horn-music.ly"
+
+\header {
+  instrument = "Horn in F"
+  tagline = ##f
+}
+
+{
+  \transpose f c' \hornNotes
+}

--- a/e2e/src/snippets/horn-music.ly
+++ b/e2e/src/snippets/horn-music.ly
@@ -1,5 +1,3 @@
-% e2e fixture: lives outside src/scores, only reachable via the
-% includePaths config option (not the score's own directory).
 hornNotes = \relative {
   \time 2/4
   r4 f8 a | cis4 f | e4 d |

--- a/e2e/src/snippets/horn-music.ly
+++ b/e2e/src/snippets/horn-music.ly
@@ -1,0 +1,6 @@
+% e2e fixture: lives outside src/scores, only reachable via the
+% includePaths config option (not the score's own directory).
+hornNotes = \relative {
+  \time 2/4
+  r4 f8 a | cis4 f | e4 d |
+}

--- a/e2e/tests/include-paths.spec.ts
+++ b/e2e/tests/include-paths.spec.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "@playwright/test";
+
+test("includePaths lets \\include resolve a file from a directory other than the score's own", async ({
+	page,
+}) => {
+	await page.goto("/score-include-paths");
+	const img = page.locator("[data-lilypond-image]");
+	await expect(img).toHaveCount(1);
+	await expect(img).toHaveAttribute("src", /\.svg$/);
+});

--- a/package/src/__tests__/index.test.ts
+++ b/package/src/__tests__/index.test.ts
@@ -66,10 +66,13 @@ interface SetupHookArgs {
 		};
 		publicDir?: URL;
 		base?: string;
+		root?: URL;
 	};
 	updateConfig: ReturnType<typeof vi.fn>;
 	logger: { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> };
 }
+
+const FAKE_ROOT = new URL("file:///project/");
 
 function baseConfig(
 	overrides: Partial<SetupHookArgs["config"]> = {},
@@ -77,6 +80,7 @@ function baseConfig(
 	return {
 		publicDir: FAKE_PUBLIC_DIR,
 		base: "/",
+		root: FAKE_ROOT,
 		...overrides,
 	};
 }
@@ -90,6 +94,7 @@ function fakeLilypondState(
 		timeout: undefined,
 		isDev: false,
 		logger: FAKE_LOGGER,
+		includePaths: [],
 		...overrides,
 	};
 }
@@ -238,6 +243,51 @@ describe("lilypond integration", () => {
 		);
 	});
 
+	it("resolves configured includePaths against config.root and stores them in state", async () => {
+		vi.doMock("@astrojs/markdown-satteri", () => ({
+			satteri: vi.fn((o: unknown) => ({ name: "satteri", options: o })),
+			isSatteriProcessor: vi.fn(() => true),
+		}));
+
+		const integration = lilypond({
+			includePaths: ["./src/snippets", "/absolute/snippets"],
+		});
+		await integration.hooks["astro:config:setup"]?.({
+			command: "build",
+			config: baseConfig({
+				markdown: { processor: { name: "satteri", options: {} } },
+			}),
+			updateConfig: vi.fn(),
+			logger: { info: vi.fn(), warn: vi.fn() },
+		} as never);
+		vi.doUnmock("@astrojs/markdown-satteri");
+
+		expect(getLilypondState().includePaths).toEqual([
+			"/project/src/snippets",
+			"/absolute/snippets",
+		]);
+	});
+
+	it("defaults state.includePaths to [] when no includePaths are configured", async () => {
+		vi.doMock("@astrojs/markdown-satteri", () => ({
+			satteri: vi.fn((o: unknown) => ({ name: "satteri", options: o })),
+			isSatteriProcessor: vi.fn(() => true),
+		}));
+
+		const integration = lilypond();
+		await integration.hooks["astro:config:setup"]?.({
+			command: "build",
+			config: baseConfig({
+				markdown: { processor: { name: "satteri", options: {} } },
+			}),
+			updateConfig: vi.fn(),
+			logger: { info: vi.fn(), warn: vi.fn() },
+		} as never);
+		vi.doUnmock("@astrojs/markdown-satteri");
+
+		expect(getLilypondState().includePaths).toEqual([]);
+	});
+
 	it.each([
 		["dev", true],
 		["build", false],
@@ -373,6 +423,21 @@ describe("lilypond integration", () => {
 			const score = scoreFrom(result);
 			expect(score.sourceName).toBe("score.ly");
 			expect(score.includePaths).toEqual(["/docs/src"]);
+		});
+
+		it("appends configured includePaths after the file's own directory", async () => {
+			const plugin = await getVitePlugin({
+				includePaths: ["./src/snippets"],
+			});
+			const result = await plugin.transform(
+				"\\score { }",
+				"/docs/src/score.ly",
+			);
+			const score = scoreFrom(result);
+			expect(score.includePaths).toEqual([
+				"/docs/src",
+				"/project/src/snippets",
+			]);
 		});
 
 		describe("alt text", () => {

--- a/package/src/__tests__/loader.test.ts
+++ b/package/src/__tests__/loader.test.ts
@@ -105,6 +105,7 @@ beforeEach(async () => {
 		timeout: undefined,
 		isDev: false,
 		logger: { warn: vi.fn(), error: vi.fn() },
+		includePaths: [],
 	});
 });
 
@@ -133,6 +134,27 @@ describe("lilypondLoader", () => {
 				composer: "Beethoven",
 				mutopiacomposer: "BeethovenLV",
 			},
+		});
+	});
+
+	it("appends state.includePaths (the integration's configured includePaths) after the file's own directory", async () => {
+		setLilypondState({
+			binaryPath: "lilypond",
+			defaults: undefined,
+			timeout: undefined,
+			isDev: false,
+			logger: { warn: vi.fn(), error: vi.fn() },
+			includePaths: ["/snippets"],
+		});
+		await writeFile(join(scoresDir, "sonata.ly"), "\\score { { c4 } }");
+
+		const loader = lilypondLoader({ base: "./src/scores" });
+		const { context, store } = createFakeContext({ root, publicDir });
+		await loader.load(context);
+
+		const entry = store.get("sonata");
+		expect(entry?.data).toMatchObject({
+			includePaths: [scoresDir, "/snippets"],
 		});
 	});
 

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import type { AstroIntegration } from "astro";
 import {
 	type AstroComponentFactory,
@@ -260,6 +261,13 @@ export interface LilypondOptions extends PluginOptions {
 	 * @default true
 	 */
 	autoInstall?: boolean | AutoInstallOptions;
+
+	/**
+	 * Extra directories to search for `\include`d files, in addition to each
+	 * score's own directory. Relative paths resolve against the project root.
+	 * @default []
+	 */
+	includePaths?: string[];
 }
 
 function lyFilePlugin(options: PluginOptions): Plugin {
@@ -271,7 +279,7 @@ function lyFilePlugin(options: PluginOptions): Plugin {
 
 			const { version } = resolveDefaults(options.defaults);
 			const src = version ? prependVersion(source, version) : source;
-			const includePaths = includePathsFor(id);
+			const includePaths = includePathsFor(id, options.includePaths);
 			const sourceName = sourceNameFor(id);
 			const assetTitle = titleFor(sourceName);
 			const meta = toLilypondMetadata(parseLyHeaderFields(source));
@@ -314,12 +322,17 @@ export default function lilypond(
 					warn: (message) => logger.warn(message),
 				});
 				options.binaryPath = binaryPath;
+				const includePaths = (options.includePaths ?? []).map((path) =>
+					fileURLToPath(new URL(path, config.root)),
+				);
+				options.includePaths = includePaths;
 				setLilypondState({
 					binaryPath,
 					defaults: options.defaults,
 					timeout: options.timeout,
 					isDev,
 					logger,
+					includePaths,
 				});
 
 				updateConfig({

--- a/package/src/loader.ts
+++ b/package/src/loader.ts
@@ -135,7 +135,10 @@ export function lilypondLoader({
 				const digest = generateDigest(source);
 
 				const src = prependVersion(source, version);
-				const includePaths = includePathsFor(filePath);
+				const includePaths = includePathsFor(
+					filePath,
+					getLilypondState().includePaths,
+				);
 				const sourceName = sourceNameFor(filePath);
 				const assetTitle = titleFor(sourceName);
 				const meta = toLilypondMetadata(headerFields);

--- a/package/src/plugins/__tests__/remark.test.ts
+++ b/package/src/plugins/__tests__/remark.test.ts
@@ -103,6 +103,22 @@ describe("remarkLilypondPlugin", () => {
 		);
 	});
 
+	it("appends the integration's configured includePaths after the file's own directory", async () => {
+		const tree = makeTree([
+			{ type: "code", lang: "lilypond", value: "\\score { }" } as Code,
+		]);
+
+		await runPlugin(tree, {
+			...BASE_OPTIONS,
+			includePaths: ["/snippets"],
+		});
+
+		expect(mockRender).toHaveBeenCalledWith(
+			"\\score { }",
+			expect.objectContaining({ includePaths: [".", "/snippets"] }),
+		);
+	});
+
 	it("leaves non-lilypond code blocks untouched", async () => {
 		const jsNode: Code = { type: "code", lang: "js", value: "const x = 1" };
 		const tree = makeTree([jsNode]);

--- a/package/src/plugins/__tests__/satteri.test.ts
+++ b/package/src/plugins/__tests__/satteri.test.ts
@@ -87,6 +87,27 @@ describe("satteriPlugin", () => {
 		);
 	});
 
+	it("appends the integration's configured includePaths after the file's own directory", async () => {
+		const plugin = satteriPlugin({
+			...BASE_OPTIONS,
+			includePaths: ["/snippets"],
+		});
+		const node: Code = { type: "code", lang: "lilypond", value: "\\score { }" };
+		const ctx = {
+			fileURL: new URL("file:///project/docs/syntax.md"),
+			indexOf: vi.fn().mockReturnValue(0),
+		};
+
+		await plugin.code?.(node, ctx as never);
+
+		expect(mockRender).toHaveBeenCalledWith(
+			"\\score { }",
+			expect.objectContaining({
+				includePaths: ["/project/docs", "/snippets"],
+			}),
+		);
+	});
+
 	it("returns undefined for non-lilypond code nodes", async () => {
 		const plugin = satteriPlugin(BASE_OPTIONS);
 		const node: Code = { type: "code", lang: "js", value: "console.log(1)" };

--- a/package/src/plugins/remark.ts
+++ b/package/src/plugins/remark.ts
@@ -20,7 +20,7 @@ export const remarkPlugin: Plugin<[PluginOptions], Root> = (options) => {
 	const renderOptions = { ...options, logger };
 	return async (tree, file) => {
 		const promises: Promise<void>[] = [];
-		const includePaths = includePathsFor(file?.path);
+		const includePaths = includePathsFor(file?.path, options.includePaths);
 		const sourceName = sourceNameFor(file?.path);
 		const title = titleFor(sourceName);
 

--- a/package/src/plugins/satteri.ts
+++ b/package/src/plugins/satteri.ts
@@ -29,7 +29,7 @@ export function satteriPlugin(options: PluginOptions): MdastPluginDefinition {
 				title: titleFor(sourceName),
 				value: node.value,
 				meta: node.meta,
-				includePaths: includePathsFor(ctx.fileURL),
+				includePaths: includePathsFor(ctx.fileURL, options.includePaths),
 				sourceName,
 			});
 			return { rawHtml };

--- a/package/src/plugins/types.ts
+++ b/package/src/plugins/types.ts
@@ -7,4 +7,5 @@ export interface PluginOptions {
 	binaryPath?: string;
 	isDev?: boolean;
 	logger?: Pick<AstroIntegrationLogger, "warn" | "error">;
+	includePaths?: string[];
 }

--- a/package/src/state.ts
+++ b/package/src/state.ts
@@ -7,6 +7,7 @@ export interface LilypondState {
 	timeout: number | undefined;
 	isDev: boolean;
 	logger: Pick<AstroIntegrationLogger, "warn" | "error">;
+	includePaths: string[];
 }
 
 const KEY = "astro-lilypond:state";

--- a/package/src/utils/__tests__/includePathsFor.test.ts
+++ b/package/src/utils/__tests__/includePathsFor.test.ts
@@ -29,4 +29,18 @@ describe("includePathsFor", () => {
 	it("returns '.' for a bare filename with no directory component", () => {
 		expect(includePathsFor("bach.ly")).toEqual(["."]);
 	});
+
+	it("appends extra paths after the source's directory", () => {
+		expect(
+			includePathsFor("/docs/src/examples/bach.ly", ["/other/dir"]),
+		).toEqual(["/docs/src/examples", "/other/dir"]);
+	});
+
+	it("returns extra paths as-is when the source is unknown", () => {
+		expect(includePathsFor(undefined, ["/other/dir"])).toEqual(["/other/dir"]);
+	});
+
+	it("defaults extra to [] when omitted", () => {
+		expect(includePathsFor("/docs/bach.ly")).toEqual(["/docs"]);
+	});
 });

--- a/package/src/utils/includePathsFor.ts
+++ b/package/src/utils/includePathsFor.ts
@@ -2,14 +2,16 @@ import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 /**
- * Derives `render()`'s `includePaths` from the source file's path or URL, so
- * `\include`d sibling files resolve even though rendering happens in a temp
- * directory. Returns `[]` when the source location is unknown.
+ * Make sure that any `\include` definitions resolve correctly when
+ * LilyPond compiles the score. `source` is the current directory or URL
+ * of the .ly file; `extra` is for user-defined locations from the
+ * config setting `includePaths`.
  */
 export function includePathsFor(
 	source: string | URL | null | undefined,
+	extra: string[] = [],
 ): string[] {
-	if (!source) return [];
+	if (!source) return extra;
 	const path = typeof source === "string" ? source : fileURLToPath(source);
-	return [dirname(path)];
+	return [dirname(path), ...extra];
 }


### PR DESCRIPTION
Adds an `includePaths` config option to extend `\include` resolution with extra directories, in addition to each score's own directory.

To enable, pass an array of directories to `includePaths` in the integration config:

```js
// astro.config.mjs
lilypond({
  includePaths: ["./src/snippets"],
})
```

This will ensure that LilyPond has access to any styles, layouts, and helper definitions which are defined separately from the score itself.

Closes #104.