### PR TITLE
fix: unbreak Astro 7 Sätteri builds blocked by optional markdown-remark import

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -51,7 +51,13 @@
 		"utils"
 	],
 	"peerDependencies": {
-		"astro": ">=7.0.0"
+		"astro": ">=7.0.0",
+		"@astrojs/markdown-remark": "^7.2.2"
+	},
+	"peerDependenciesMeta": {
+		"@astrojs/markdown-remark": {
+			"optional": true
+		}
 	},
 	"dependencies": {
 		"astro-emit-asset": "^0.1.4",

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -372,7 +372,7 @@ export default function lilypond(
 
 				if (existingProcessor?.name === "unified") {
 					const { unified, isUnifiedProcessor } = await import(
-						"@astrojs/markdown-remark"
+						/* @vite-ignore */ "@astrojs/markdown-remark"
 					);
 
 					if (!isUnifiedProcessor(existingProcessor)) {


### PR DESCRIPTION
On Astro 7 with the new default Sätteri processor, I'm finding that any page that renders a `<Score />` fails the build with this...

```
[vite]: Rolldown failed to resolve import "@astrojs/markdown-remark"
  from "astro-lilypond/dist/index.js".
```

I don't know how you feel about this. I couldn't work out the issue. I used an LLM-based tool to help uncover the issue I was finding. I saw your blogpost about how you quit your job to avoid AI stuff so sorry if this is weird for you.

This is my writeup from what (it 'says') it found. You might prefer a different approach of course but I thought I'd make the PR to show you the idea here. :-)

`@astrojs/markdown-remark` is an optional peer of `astro`. This means it isn't installed unless a user opts into the legacy `unified()` markdown processor. `astro-lilypond` only imports `@astrojs/markdown-remark` inside the `unified` branch. That branch never runs under Sätteri.

But Rolldown statically resolves the specifier when it bundles the integration for the prerender environment, so it breaks for me on the default markdown processor.

This PR adds `/* @vite-ignore */` to the `unified` import so Vite/Rolldown skip static resolution and defer the import to runtime, where it only fires on the path that actually needs it.

I left the `satteri` import alone. It's a regular dependency of `astro` (not an optional peer), so it's always installed and always resolves. Its branch runs at runtime on the default processor, so the import has to fire.

The PR also declares `@astrojs/markdown-remark` as an optional peer in `package.json` with `peerDependenciesMeta`, matching how `astro` itself declares it, so package managers know it may be missing.