### PR TITLE
feat: forward loading/decoding/fetchpriority onto rendered score images

### DIFF
--- a/.changeset/score-image-loading-attrs.md
+++ b/.changeset/score-image-loading-attrs.md
@@ -1,0 +1,20 @@
+---
+"astro-lilypond": minor
+---
+
+Adds `loading`, `decoding`, and `fetchpriority` props to `<Score />` (and to the `Score` returned from `getScore()`), forwarded onto every rendered `<img>` — including each page in a multi-page group.
+
+These are the standard `<img>` fetch/decode hints. They're forwarded only when you pass them, so existing output is unchanged. The motivating use case is a list or gallery of many scores: mark off-screen scores `loading="lazy" decoding="async"` so they don't fetch until scrolled near, and mark an above-the-fold/LCP score `loading="eager" fetchpriority="high"` so the browser fetches it on the critical path.
+
+```astro
+---
+import { Score } from "astro-lilypond";
+import sonata from "./sonata.ly";
+---
+
+<Score
+  content={sonata}
+  loading="lazy"
+  decoding="async"
+/>
+```

--- a/docs/src/content/docs/reference/component.mdx
+++ b/docs/src/content/docs/reference/component.mdx
@@ -17,6 +17,9 @@ interface ScoreProps {
   pageLimit?: number;
   class?: string;
   style?: string;
+  loading?: "lazy" | "eager";
+  decoding?: "async" | "sync" | "auto";
+  fetchpriority?: "high" | "low" | "auto";
   alt?: string;
 }
 ```
@@ -70,6 +73,37 @@ Class name(s) applied to the rendered `<img>` (or `<ol>`, for multi-page scores)
 **Type:** `string`
 
 Inline styles applied directly to the rendered element.
+
+### `loading`
+
+**Type:** `"lazy" | "eager"`
+
+`loading` hint forwarded onto every rendered `<img>`. Set `loading="lazy"` so off-screen scores in a long list don't fetch until scrolled near; for an above-the-fold or LCP score, use `loading="eager"` with [`fetchpriority="high"`](#fetchpriority).
+
+```astro title="LazyGallery.astro"
+<Score content={sonata} loading="lazy" decoding="async" />
+```
+
+### `decoding`
+
+**Type:** `"async" | "sync" | "auto"`
+
+`decoding` hint forwarded onto every rendered `<img>`. `decoding="async"` keeps image decoding off the main thread.
+
+### `fetchpriority`
+
+**Type:** `"high" | "low" | "auto"`
+
+`fetchpriority` hint forwarded onto every rendered `<img>`. Set `fetchpriority="high"` for an above-the-fold or LCP score so the browser fetches it on the critical path; `"low"` deprioritizes a below-the-fold score behind more urgent work. With `loading="lazy"` the fetch is already deferred, so `fetchpriority` matters most for an eager LCP score.
+
+```astro title="LcpScore.astro"
+<Score
+  content={heroSonata}
+  loading="eager"
+  decoding="async"
+  fetchpriority="high"
+/>
+```
 
 ### `alt`
 

--- a/package/src/__tests__/index.test.ts
+++ b/package/src/__tests__/index.test.ts
@@ -815,6 +815,57 @@ describe("getScore()", () => {
 		expect(html).toContain('style="width: 50%"');
 	});
 
+	it("forwards loading through Score onto the rendered <img>", async () => {
+		mockEmitLilypondAsset.mockResolvedValueOnce([{ src: "/_astro/a.svg" }]);
+		const { Score } = await publicGetScore(SCORE);
+		const container = await AstroContainer.create();
+		const html = await container.renderToString(Score, {
+			props: { loading: "lazy" },
+		});
+		expect(html).toContain('loading="lazy"');
+		expect(html).toContain("data-lilypond-image");
+	});
+
+	it("forwards decoding through Score onto the rendered <img>", async () => {
+		mockEmitLilypondAsset.mockResolvedValueOnce([{ src: "/_astro/a.svg" }]);
+		const { Score } = await publicGetScore(SCORE);
+		const container = await AstroContainer.create();
+		const html = await container.renderToString(Score, {
+			props: { decoding: "async" },
+		});
+		expect(html).toContain('decoding="async"');
+	});
+
+	it("forwards fetchpriority through Score onto the rendered <img>", async () => {
+		mockEmitLilypondAsset.mockResolvedValueOnce([{ src: "/_astro/a.svg" }]);
+		const { Score } = await publicGetScore(SCORE);
+		const container = await AstroContainer.create();
+		const html = await container.renderToString(Score, {
+			props: { fetchpriority: "high" },
+		});
+		expect(html).toContain('fetchpriority="high"');
+	});
+
+	it("forwards loading/decoding/fetchpriority onto every <img> in a multi-page group", async () => {
+		mockEmitLilypondAsset.mockResolvedValueOnce([
+			{ src: "/_astro/a.svg" },
+			{ src: "/_astro/b.svg" },
+		]);
+		const { Score } = await publicGetScore(SCORE);
+		const container = await AstroContainer.create();
+		const html = await container.renderToString(Score, {
+			props: {
+				loading: "lazy",
+				decoding: "async",
+				fetchpriority: "low",
+			},
+		});
+		expect(html).toContain("data-lilypond-group");
+		expect(html.match(/loading="lazy"/g)).toHaveLength(2);
+		expect(html.match(/decoding="async"/g)).toHaveLength(2);
+		expect(html.match(/fetchpriority="low"/g)).toHaveLength(2);
+	});
+
 	it("renders multiple pages as an <ol data-lilypond-group> of <li><img>s", async () => {
 		mockEmitLilypondAsset.mockResolvedValueOnce([
 			{ src: "/_astro/a.svg" },
@@ -986,6 +1037,23 @@ describe("Score component", () => {
 		});
 		expect(html).toContain('class="extra"');
 		expect(html).toContain('style="width: 50%"');
+	});
+
+	it("forwards loading/decoding/fetchpriority from <Score /> onto the rendered <img>", async () => {
+		mockEmitLilypondAsset.mockResolvedValueOnce([{ src: "/_astro/a.svg" }]);
+		const container = await AstroContainer.create();
+		const html = await container.renderToString(PublicScore, {
+			props: {
+				content: SCORE,
+				loading: "lazy",
+				decoding: "async",
+				fetchpriority: "high",
+			},
+		});
+		expect(html).toContain('loading="lazy"');
+		expect(html).toContain('decoding="async"');
+		expect(html).toContain('fetchpriority="high"');
+		expect(html).toContain("data-lilypond-image");
 	});
 
 	it("renders multiple pages as an <ol data-lilypond-group> of <li><img>s", async () => {

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -108,6 +108,22 @@ interface ScoreImageProps {
 	pageLimit?: number;
 	class?: string;
 	style?: string;
+	/**
+	 * `loading` hint forwarded onto every rendered `<img>`. Set `"lazy"` so
+	 * off-screen scores in a list don't fetch until scrolled near, or `"eager"`
+	 * (with `fetchpriority="high"`) for an above-the-fold/LCP score.
+	 */
+	loading?: "lazy" | "eager";
+	/**
+	 * `decoding` hint forwarded onto every rendered `<img>`. `"async"` keeps
+	 * image decoding off the main thread.
+	 */
+	decoding?: "async" | "sync" | "auto";
+	/**
+	 * `fetchpriority` hint forwarded onto every rendered `<img>`. `"high"` for
+	 * an above-the-fold/LCP score, `"low"` to defer a below-the-fold score.
+	 */
+	fetchpriority?: "high" | "low" | "auto";
 	alt?: string;
 }
 
@@ -120,6 +136,9 @@ function createScoreComponent(
 			class: props.class,
 			style: props.style,
 			pageLimit: props.pageLimit,
+			loading: props.loading,
+			decoding: props.decoding,
+			fetchpriority: props.fetchpriority,
 		});
 		return renderTemplate`${unescapeHTML(html)}`;
 	});

--- a/package/src/utils/__tests__/renderedHtml.test.ts
+++ b/package/src/utils/__tests__/renderedHtml.test.ts
@@ -204,4 +204,91 @@ describe("renderedHtml", () => {
 			).toBe("");
 		});
 	});
+
+	describe("loading/decoding/fetchpriority hints", () => {
+		it("omits loading/decoding/fetchpriority by default (non-breaking)", () => {
+			expect(
+				renderedHtml(
+					[{ src: "/a.svg", width: undefined, height: undefined }],
+					"",
+				),
+			).toBe('<img data-lilypond-image src="/a.svg" alt>');
+		});
+
+		it("forwards loading onto a single-page <img>", () => {
+			expect(
+				renderedHtml(
+					[{ src: "/a.svg", width: undefined, height: undefined }],
+					"",
+					{ loading: "lazy" },
+				),
+			).toBe('<img data-lilypond-image src="/a.svg" alt loading="lazy">');
+		});
+
+		it("forwards decoding onto a single-page <img>", () => {
+			expect(
+				renderedHtml(
+					[{ src: "/a.svg", width: undefined, height: undefined }],
+					"",
+					{ decoding: "async" },
+				),
+			).toBe('<img data-lilypond-image src="/a.svg" alt decoding="async">');
+		});
+
+		it("forwards fetchpriority onto a single-page <img>", () => {
+			expect(
+				renderedHtml(
+					[{ src: "/a.svg", width: undefined, height: undefined }],
+					"",
+					{ fetchpriority: "high" },
+				),
+			).toBe('<img data-lilypond-image src="/a.svg" alt fetchpriority="high">');
+		});
+
+		it("forwards all three onto a single-page <img> with class/style preserved", () => {
+			expect(
+				renderedHtml(
+					[{ src: "/a.svg", width: undefined, height: undefined }],
+					"",
+					{
+						class: "hero",
+						style: "width: 50%",
+						loading: "lazy",
+						decoding: "async",
+						fetchpriority: "high",
+					},
+				),
+			).toBe(
+				'<img data-lilypond-image class="hero" src="/a.svg" alt loading="lazy" decoding="async" fetchpriority="high" style="width: 50%">',
+			);
+		});
+
+		it("forwards loading/decoding/fetchpriority onto every <img> in a multi-page group", () => {
+			expect(
+				renderedHtml(
+					[
+						{ src: "/a.svg", width: 100, height: 50 },
+						{ src: "/b.svg", width: 100, height: 60 },
+					],
+					"Sonata",
+					{ loading: "lazy", decoding: "async", fetchpriority: "low" },
+				),
+			).toBe(
+				"<ol data-lilypond-group>" +
+					'<li><img data-lilypond-image src="/a.svg" width="100" height="50" alt="Sonata" loading="lazy" decoding="async" fetchpriority="low"></li>' +
+					'<li><img data-lilypond-image src="/b.svg" width="100" height="60" alt="Sonata" loading="lazy" decoding="async" fetchpriority="low"></li>' +
+					"</ol>",
+			);
+		});
+
+		it("only adds the hints that are provided", () => {
+			expect(
+				renderedHtml(
+					[{ src: "/a.svg", width: undefined, height: undefined }],
+					"",
+					{ decoding: "async" },
+				),
+			).toBe('<img data-lilypond-image src="/a.svg" alt decoding="async">');
+		});
+	});
 });

--- a/package/src/utils/renderedHtml.ts
+++ b/package/src/utils/renderedHtml.ts
@@ -1,8 +1,8 @@
 import { addAttribute } from "astro/runtime/server/index.js";
 import type { LilypondPage } from "../index.js";
 
-function imgTag(page: LilypondPage, alt: string): string {
-	return `<img data-lilypond-image${addAttribute(page.src, "src")}${addAttribute(page.width, "width")}${addAttribute(page.height, "height")}${addAttribute(alt, "alt")}>`;
+function imgTag(page: LilypondPage, alt: string, imageAttrs: string): string {
+	return `<img data-lilypond-image${addAttribute(page.src, "src")}${addAttribute(page.width, "width")}${addAttribute(page.height, "height")}${addAttribute(alt, "alt")}${imageAttrs}>`;
 }
 
 export interface RenderedHtmlOptions {
@@ -12,6 +12,22 @@ export interface RenderedHtmlOptions {
 	style?: string;
 	/** Render only the first `n` pages. */
 	pageLimit?: number;
+	/**
+	 * `loading` hint forwarded onto every rendered `<img>`. Set `"lazy"` so
+	 * off-screen scores in a list don't fetch until scrolled near, or `"eager"`
+	 * (with `fetchpriority="high"`) for an above-the-fold/LCP score.
+	 */
+	loading?: "lazy" | "eager";
+	/**
+	 * `decoding` hint forwarded onto every rendered `<img>`. `"async"` keeps
+	 * image decoding off the main thread.
+	 */
+	decoding?: "async" | "sync" | "auto";
+	/**
+	 * `fetchpriority` hint forwarded onto every rendered `<img>`. `"high"` for
+	 * an above-the-fold/LCP score, `"low"` to defer a below-the-fold score.
+	 */
+	fetchpriority?: "high" | "low" | "auto";
 }
 
 export function renderedHtml(
@@ -19,20 +35,33 @@ export function renderedHtml(
 	alt: string,
 	options: RenderedHtmlOptions = {},
 ): string {
-	const { class: className, style, pageLimit } = options;
+	const {
+		class: className,
+		style,
+		pageLimit,
+		loading,
+		decoding,
+		fetchpriority,
+	} = options;
 	const limitedPages =
 		pageLimit === undefined ? pages : pages.slice(0, pageLimit);
 	if (limitedPages.length === 0) return "";
 
 	const classAttr = addAttribute(className, "class");
 	const styleAttr = addAttribute(style, "style");
+	// Per-image loading/decoding/fetchpriority hints, forwarded onto every
+	// rendered <img> (single-page and each page in a multi-page <ol>).
+	const imageAttrs =
+		addAttribute(loading, "loading") +
+		addAttribute(decoding, "decoding") +
+		addAttribute(fetchpriority, "fetchpriority");
 
 	if (limitedPages.length === 1) {
 		const page = limitedPages[0];
-		return `<img data-lilypond-image${classAttr}${addAttribute(page.src, "src")}${addAttribute(page.width, "width")}${addAttribute(page.height, "height")}${addAttribute(alt, "alt")}${styleAttr}>`;
+		return `<img data-lilypond-image${classAttr}${addAttribute(page.src, "src")}${addAttribute(page.width, "width")}${addAttribute(page.height, "height")}${addAttribute(alt, "alt")}${imageAttrs}${styleAttr}>`;
 	}
 
 	return `<ol data-lilypond-group${classAttr}${styleAttr}>${limitedPages
-		.map((page) => `<li>${imgTag(page, alt)}</li>`)
+		.map((page) => `<li>${imgTag(page, alt, imageAttrs)}</li>`)
 		.join("")}</ol>`;
 }


### PR DESCRIPTION
## What

`<Score />` (and the `Score` returned from `getScore()`) silently dropped the `loading`, `decoding`, and `fetchpriority` props. The chain was:

- `Score` spreads `…imageProps` onto an inner component ✓
- but `createScoreComponent` only forwards `class`/`style`/`pageLimit` to `renderedHtml`
- and `renderedHtml` only renders those three

So any `loading`/`decoding`/`fetchpriority` passed to `<Score />` vanished.

This PR forwards those three standard `<img>` fetch/decode hints onto **every** rendered `<img>` — the single-page image and each `<li><img>` inside a multi-page `<ol data-lilypond-group>`.

## Design

**Additive only — no defaults change.** The hints are forwarded only when passed, so existing output is byte-identical (verified by the unchanged existing tests). No new behavior is forced on current users; the PR just makes the attributes controllable.

Why not default `loading="lazy"` / `decoding="async"` in the library? The library can't know which score is the LCP element above the fold. Defaulting `loading="lazy"` can mildly regress an above-the-fold LCP score, and the right priority signal is relative — only the caller can pick it. So the library forwards and the caller decides, following the web.dev gallery/LCP pattern:

- off-screen scores → `loading="lazy" decoding="async"` (don't fetch until scrolled near)
- the one above-the-fold/LCP score → `loading="eager" fetchpriority="high"` (fetch on the critical path)

`fetchpriority` has no useful default here precisely because its point is *relative* priority; with `loading="lazy"` the fetch is already deferred, so `fetchpriority` matters most for the eager LCP score. So it's forwarded with no default.

## Tests

Test-first. New tests added in `renderedHtml.test.ts` (exact-HTML) and `index.test.ts` (`AstroContainer.renderToString` through both `getScore().Score` and `<Score />`), covering single-page, multi-page (every `<img>`), and per-attribute forwarding. The existing 370 tests stay green (unchanged), 11 new tests added → **381 passing**.

```
Test Files  30 passed (30)
Tests       381 passed (381)
```

`pnpm check`, `pnpm build`, and `pnpm test` all clean.

## Changeset

Marked `minor` — new optional, non-breaking public props on `<Score />`.

## Docs

`docs/src/content/docs/reference/component.mdx` updated: the `ScoreProps` interface block and three new prop sections (`loading`, `decoding`, `fetchpriority`) with the lazy-gallery and eager-LCP usage examples.