### PR TITLE
Update 'publish' to 'publish-script' in Changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,6 @@ jobs:
       - name: Create version PR or publish
         uses: changesets/action@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2.0.0
         with:
-          publish: pnpm release
+          publish-script: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Changesets action is failing post-upgrade in #130 with the following:

```
Warning: Unexpected input(s) 'publish', valid inputs are ['github-token', 'publish-script', 'version-script', 'commit-message', 'pr-title', 'pr-draft', 'pr-base-branch', 'create-github-releases', 'push-git-tags', 'push-with-git-cli']
Run changesets/action@22ccf9aa43179fe9e27dc62e575971d28cce197c
Error: Error: The following inputs have been renamed:
- "publish" -> "publish-script"
Please update your workflow file.
Error: The following inputs have been renamed:
- "publish" -> "publish-script"
Please update your workflow file.
```

Update the workflow.